### PR TITLE
Add rich menu switch object to action object and postback.params

### DIFF
--- a/src/events/postback.rs
+++ b/src/events/postback.rs
@@ -19,8 +19,16 @@ pub struct PostBack {
 }
 
 #[derive(Deserialize, Debug)]
-pub struct Params {
-    pub date: Option<String>,
-    pub time: Option<String>,
-    pub datetime: Option<String>,
+#[serde(untagged)]
+pub enum Params {
+    RichMenuSwitch {
+        #[serde(rename = "newRichMenuAliasId")]
+        new_rich_menu_alias_id: String,
+        status: String,
+    },
+    DatetimePicker {
+        date: Option<String>,
+        time: Option<String>,
+        datetime: Option<String>,
+    },
 }

--- a/src/objects/action.rs
+++ b/src/objects/action.rs
@@ -51,6 +51,12 @@ pub enum ActionType {
     CameraRoll {},
     #[serde(rename = "location")]
     Location {},
+    #[serde(rename = "richmenuswitch")]
+    RichMenuSwitch {
+        #[serde(rename = "richMenuAliasId")]
+        rich_menu_alias_id: String,
+        data: String,
+    },
 }
 
 /// Alt uri object

--- a/tests/events_test/mod.rs
+++ b/tests/events_test/mod.rs
@@ -1,2 +1,3 @@
 pub mod account_link_test;
 pub mod messages_test;
+pub mod postback_test;

--- a/tests/events_test/postback_test.rs
+++ b/tests/events_test/postback_test.rs
@@ -1,0 +1,145 @@
+#[cfg(test)]
+mod postback_test {
+    extern crate line_bot_sdk_rust as line;
+
+    use line::events::postback::Params;
+    use line::events::source::SouceType;
+    use line::events::{EventType, Events};
+
+    #[test]
+    fn test_datetime_picker_postback_valid() {
+        let string = r#"
+          {
+            "destination": "xxxxxxxxxx",
+            "events": [
+              {
+                "replyToken": "b60d432864f44d079f6d8efe86cf404b",
+                "type": "postback",
+                "mode": "active",
+                "source": {
+                  "userId": "U91eeaf62d...",
+                  "type": "user"
+                },
+                "timestamp": 1513669370317,
+                "postback": {
+                  "data": "storeId=12345",
+                  "params": {
+                    "datetime": "2017-12-25T01:00"
+                  }
+                }
+              }
+            ]
+          }
+        "#;
+
+        let events: Events = serde_json::from_str(&string).unwrap();
+
+        // events length test
+        assert_eq!(1, events.events.len());
+
+        // event type test
+        match &events.events[0].r#type {
+            EventType::PostBackEvent(post_back_event) => {
+                // check events field value
+                assert_eq!("xxxxxxxxxx", events.destination);
+
+                // check post_back_event field value
+                assert_eq!(
+                    "b60d432864f44d079f6d8efe86cf404b",
+                    post_back_event.reply_token
+                );
+                assert_eq!("active", post_back_event.mode);
+                assert_eq!(1513669370317, post_back_event.timestamp);
+
+                // check source type
+                match &post_back_event.source.r#type {
+                    SouceType::User(source) => {
+                        assert_eq!("U91eeaf62d...", source.user_id);
+                    }
+                    _ => panic!("Expected SouceType::User"),
+                }
+
+                // check postback field
+                assert_eq!("storeId=12345", post_back_event.postback.data);
+                match &post_back_event.postback.params {
+                    Some(Params::DatetimePicker { datetime, .. }) => {
+                        assert_eq!(&Some(String::from("2017-12-25T01:00")), datetime);
+                    }
+                    _ => panic!("Expected Params::DatetimePicker"),
+                }
+            }
+            _ => panic!("Expected EventType::AccountLinkEvent"),
+        }
+    }
+
+    #[test]
+    fn test_rich_menu_switch_postback_valid() {
+        let string = r#"
+          {
+            "destination": "xxxxxxxxxx",
+            "events": [
+              {
+                "replyToken": "b60d432864f44d079f6d8efe86cf404b",
+                "type": "postback",
+                "mode": "active",
+                "source": {
+                  "userId": "U91eeaf62d...",
+                  "type": "user"
+                },
+                "timestamp": 1619754620404,
+                "postback": {
+                  "data": "richmenu-changed-to-b",
+                  "params": {
+                    "newRichMenuAliasId": "richmenu-alias-b",
+                    "status": "SUCCESS"
+                  }
+                }
+              }
+            ]
+          }
+        "#;
+
+        let events: Events = serde_json::from_str(&string).unwrap();
+
+        // events length test
+        assert_eq!(1, events.events.len());
+
+        // event type test
+        match &events.events[0].r#type {
+            EventType::PostBackEvent(post_back_event) => {
+                // check events field value
+                assert_eq!("xxxxxxxxxx", events.destination);
+
+                // check post_back_event field value
+                assert_eq!(
+                    "b60d432864f44d079f6d8efe86cf404b",
+                    post_back_event.reply_token
+                );
+                assert_eq!("active", post_back_event.mode);
+                assert_eq!(1619754620404, post_back_event.timestamp);
+
+                // check source type
+                match &post_back_event.source.r#type {
+                    SouceType::User(source) => {
+                        assert_eq!("U91eeaf62d...", source.user_id);
+                    }
+                    _ => panic!("Expected SouceType::User"),
+                }
+
+                // check postback field
+                assert_eq!("richmenu-changed-to-b", post_back_event.postback.data);
+                match &post_back_event.postback.params {
+                    Some(Params::RichMenuSwitch {
+                        new_rich_menu_alias_id,
+                        status,
+                    }) => {
+                        assert_eq!("richmenu-alias-b", new_rich_menu_alias_id);
+                        assert_eq!("SUCCESS", status);
+                    }
+                    _ => panic!("Expected Params::DatetimePicker"),
+                }
+            }
+            _ => panic!("Expected EventType::AccountLinkEvent"),
+        }
+    }
+}

--- a/tests/objects_test/action_test.rs
+++ b/tests/objects_test/action_test.rs
@@ -153,3 +153,24 @@ fn test_location_action_valid() {
     };
     assert_eq!(json!(location_action), expected_json);
 }
+
+#[test]
+fn test_richmenu_switch_action_valid() {
+    let expected_str: &str = r#"
+        {
+            "type": "richmenuswitch",
+            "richMenuAliasId": "richmenu-alias-b",
+            "data":"richmenu-changed-to-b"
+        }
+    "#;
+    let expected_json: Value = serde_json::from_str(expected_str).unwrap();
+
+    let location_action = Action {
+        r#type: ActionType::RichMenuSwitch {
+            rich_menu_alias_id: String::from("richmenu-alias-b"),
+            data: String::from("richmenu-changed-to-b"),
+        },
+        label: None,
+    };
+    assert_eq!(json!(location_action), expected_json);
+}


### PR DESCRIPTION
# Overview
A new feature to switch between rich menus has been added to the Messaging API.
https://developers.line.biz/en/news/2021/06/21/switch-between-multiple-rich-menus/

* implement rich menu switch action object
* implement new postback.params object for rich menu switch action