### PR TITLE
chore: upgrade crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,16 +18,16 @@ actix_support = ["actix-web"]
 
 [dependencies]
 actix-web = { version = "3", optional = true, default-features = false }
-base64 = "0.9.2"
-bytes = "0.4"
+base64 = "0.13.0"
+bytes = "1.1.0"
 chrono = "0.4"
-hmac = "0.6.2"
+hmac = "0.12.1"
 reqwest = { version = "0.11.0", features = ["blocking", "json"] }
 rocket = { version = "0.4", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0.97"
 serde_json = "1.0"
-sha2 = "0.7.1"
+sha2 = "0.10.2"
 
 [dev-dependencies]
 dotenv = "0.15.0"

--- a/examples/create_signature.rs
+++ b/examples/create_signature.rs
@@ -5,15 +5,16 @@ use line::webhook::validate_signature;
 use base64::encode;
 use hmac::{Hmac, Mac};
 use sha2::Sha256;
+use std::io::Write;
 
 // Signature confirmation
 pub fn create_signature(channel_secret: &str, body: &str) -> String {
     type HmacSha256 = Hmac<Sha256>;
 
-    let mut mac =
-        HmacSha256::new_varkey(channel_secret.as_bytes()).expect("HMAC can take key of any size");
-    mac.input(body.as_bytes());
-    return encode(&mac.result().code().to_vec());
+    let mut mac = HmacSha256::new_from_slice(channel_secret.as_bytes())
+        .expect("HMAC can take key of any size");
+    mac.write_all(body.as_bytes()).unwrap();
+    return encode(&mac.finalize().into_bytes());
 }
 
 fn main() {

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -3,6 +3,7 @@
 use base64::encode;
 use hmac::{Hmac, Mac};
 use sha2::Sha256;
+use std::io::Write;
 
 /// Signature validator
 /// # Note
@@ -18,8 +19,8 @@ use sha2::Sha256;
 pub fn validate_signature(channel_secret: &str, signature: &str, body: &str) -> bool {
     type HmacSha256 = Hmac<Sha256>;
 
-    let mut mac =
-        HmacSha256::new_varkey(channel_secret.as_bytes()).expect("HMAC can take key of any size");
-    mac.input(body.as_bytes());
-    encode(&mac.result().code().to_vec()) == signature
+    let mut mac = HmacSha256::new_from_slice(channel_secret.as_bytes())
+        .expect("HMAC can take key of any size");
+    mac.write_all(body.as_bytes()).unwrap();
+    encode(&mac.finalize().into_bytes()) == signature
 }


### PR DESCRIPTION
it seems that some of the crates version were yanked and cargo will
prohibit lib users from installing those dependencies.