### PR TITLE
Update hmac and sha2 crates because using deprecated version now

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,13 @@ actix-web = { version = "3", optional = true, default-features = false }
 base64 = "0.9.2"
 bytes = "0.4"
 chrono = "0.4"
-hmac = "0.6.2"
+hmac = "0.7.1"
 reqwest = { version = "0.11.0", features = ["blocking", "json"] }
 rocket = { version = "0.4", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0.97"
 serde_json = "1.0"
-sha2 = "0.7.1"
+sha2 = "0.8"
 
 [dev-dependencies]
 dotenv = "0.15.0"


### PR DESCRIPTION
## What

Update `hmac` and `sha2` crates.

## Why

Hi @nanato12 , nice crate!! But I realized now I can't build this crate because using deprecated crates.
When I run `cargo build` then shows bellow error.

> error: failed to select a version for the requirement `crypto-mac = "^0.6"`
> candidate versions found which didn't match: 0.11.1, 0.11.0, 0.10.1, ...
> location searched: crates.io index
> required by package `hmac v0.6.3`

As error log describes, crypto-mac `0.6.2` has already yanked.
https://crates.io/crates/crypto-mac/0.6.2

You should update crypto-mac to > 0.7.0 or higher. So I update it.

## How

`hmac` `0.7.1` is the minimum version that depends on `^0.7` of `crypto-mac` crate. So I just update it.
https://crates.io/crates/hmac/0.7.1/dependencies

And then, this version of `hmac` depends on `^0.8` of sha2 crate, so I update it also.

## Test resutls

> 
>      Running tests/lib.rs (target/debug/deps/lib-054384e29a881be8)
> 
> running 16 tests
> test messages_test::text_message_test::text_message_test::test_text_message_invalid ... ok
> test objects_test::action_test::test_camera_action_valid ... ok
> test messages_test::text_message_test::text_message_test::test_text_message_valid ... ok
> test objects_test::action_test::test_camera_roll_action_valid ... ok
> test objects_test::action_test::test_datetimepicker_action_valid ... ok
> test objects_test::action_test::test_message_action_valid ... ok
> test objects_test::action_test::test_location_action_valid ... ok
> test objects_test::action_test::test_postback_action_valid ... ok
> test objects_test::action_test::test_uri_action_valid ... ok
> test messages_test::text_message_test::text_message_test::test_text_message_with_emoji_valid ... ok
> test messages_test::text_message_test::text_message_test::test_text_message_with_emoji_invalid ... ok
> test objects_test::narrowcast_test::recipient_test::recipient_test::test_recipient_invalid ... ok
> test objects_test::narrowcast_test::recipient_test::recipient_test::test_recipient_valid ... ok
> test other_test::narrowcast_data_test::narrowcast_data_test::test_data_valid ... ok
> test events_test::account_link_test::account_link_test::test_parse_valid ... ok
> test events_test::messages_test::text_message_test::text_message_test::test_parse_valid ... ok
> 
> test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
> 
>      Running tests/webhook_test.rs (target/debug/deps/webhook_test-4b493974f5710644)
> 
> running 4 tests
> test webhook_test::test_validate_signature_invalid_3 ... ok
> test webhook_test::test_validate_signature_invalid_2 ... ok
> test webhook_test::test_validate_signature_invalid ... ok
> test webhook_test::test_validate_signature_valid ... ok
> 
> test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s