### PR TITLE
Add GitHub Actions [cargo publish, release note, rust]

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,20 @@
+changelog:
+  categories:
+    - title: 🚀 New Features
+      labels:
+        - feature
+    - title: 📄 New Documentation
+      labels:
+        - documentation
+    - title: 🐛 Fixed Bug
+      labels:
+        - bug
+    - title: ✔ Changes to GitHub Actions
+      labels:
+        - actions
+    - title: 🎉 Changes for Release
+      labels:
+        - release
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -6,10 +6,13 @@ changelog:
     - title: 📄 New Documentation
       labels:
         - documentation
-    - title: 🐛 Fixed Bug
+    - title: 🐛 Bug Fixes
       labels:
         - bug
-    - title: ✔ Changes to GitHub Actions
+    - title: 🔧 Refactoring
+      labels:
+        - refactor
+    - title: ✅ Changes to GitHub Actions
       labels:
         - actions
     - title: 🎉 Changes for Release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,19 @@
+name: cargo publish
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: login
+        run: cargo login ${{ secrets.CARGO_TOKEN }}
+
+      - name: publish
+        run: cargo publish

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,11 +2,18 @@ name: Rust
 
 on:
   pull_request:
-    branches:
-      - develop
+    paths:
+      - .github/workflows/rust.yml
+      - "**.toml"
+      - "**.rs"
+
   push:
     branches:
       - develop
+    paths:
+      - .github/workflows/rust.yml
+      - "**.toml"
+      - "**.rs"
 
 jobs:
   build:
@@ -37,3 +44,12 @@ jobs:
       - name: Run tests
         run: cargo test --verbose --tests
         continue-on-error: ${{ matrix.rust == 'nightly' }}
+
+      - name: Build for examples
+        run: cargo build --verbose
+        working-directory: examples
+
+      - name: Run tests for examples
+        run: cargo test --verbose --tests
+        continue-on-error: ${{ matrix.rust == 'nightly' }}
+        working-directory: examples


### PR DESCRIPTION
# Overview

Add or update three GitHub Actions workflows

## Changes

### Add publish.yml

- Automatically publish to crate.io after creating a release

### Add release.yml

- Automatic generation of release notes when creating a release

### Change rust.yml

- Also check Examples