### PR TITLE
Add .claude/CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,41 +2,66 @@
 
 ## Rules
 
-- This is an OSS project. All code, comments, commit messages, and documentation MUST be in English.
+- This is an OSS project.
+  All code, comments, commit messages,
+  and documentation MUST be in English.
 - License: Apache-2.0
 - Main branch: `develop`
 
 ## Reference SDKs
 
-This SDK MUST follow the same architecture and patterns as the official LINE Bot SDKs:
+This SDK MUST follow the same architecture
+and patterns as the official LINE Bot SDKs:
 
-- **Java:** https://github.com/line/line-bot-sdk-java
-- **Python:** https://github.com/line/line-bot-sdk-python
-- **Go:** https://github.com/line/line-bot-sdk-go
-- **Node.js:** https://github.com/line/line-bot-sdk-nodejs
-- **PHP:** https://github.com/line/line-bot-sdk-php
-- **Ruby:** https://github.com/line/line-bot-sdk-ruby
+- [Java](https://github.com/line/line-bot-sdk-java)
+- [Python](https://github.com/line/line-bot-sdk-python)
+- [Go](https://github.com/line/line-bot-sdk-go)
+- [Node.js](https://github.com/line/line-bot-sdk-nodejs)
+- [PHP](https://github.com/line/line-bot-sdk-php)
+- [Ruby](https://github.com/line/line-bot-sdk-ruby)
 
-When in doubt about architecture, code generation approach, or project structure, refer to these repositories.
+When in doubt about architecture, code generation
+approach, or project structure, refer to these.
 
 ## Key Patterns (shared across all official SDKs)
 
-1. **OpenAPI-driven code generation** — API clients and models are auto-generated from `line-openapi/` submodule YAML specs using a custom OpenAPI Generator plugin (Java/Maven).
-2. **`generate-code.py` orchestration** — A Python script drives the generation pipeline (most SDKs use this).
-3. **Custom templates (Pebble)** — Java, Go, Node.js, Ruby use Pebble templates for codegen customization.
-4. **Per-service module isolation** — Each LINE API surface is an independent module/crate.
-5. **Webhook = models only** — `webhook.yml` generates only model types, no API client.
-6. **Signature validation is hand-written** — HMAC-SHA256 verification of `x-line-signature`.
-7. **Generated code is committed** — Regenerated only when OpenAPI specs change.
-8. **Renovate bot** keeps `line-openapi` submodule up to date automatically.
+1. **OpenAPI-driven code generation** —
+   API clients and models are auto-generated from
+   `line-openapi/` submodule YAML specs
+   using a custom OpenAPI Generator plugin
+   (Java/Maven).
+2. **`generate-code.py` orchestration** —
+   A Python script drives the generation pipeline.
+3. **Custom templates (Pebble)** —
+   Java, Go, Node.js, Ruby use Pebble templates
+   for codegen customization.
+4. **Per-service module isolation** —
+   Each LINE API surface is an independent
+   module/crate.
+5. **Webhook = models only** —
+   `webhook.yml` generates only model types,
+   no API client.
+6. **Signature validation is hand-written** —
+   HMAC-SHA256 verification of `x-line-signature`.
+7. **Generated code is committed** —
+   Regenerated only when OpenAPI specs change.
+8. **Renovate bot** keeps `line-openapi` submodule
+   up to date automatically.
 
 ## Code Rules
 
-- `core/line_*/` crates (except `core/lib/`) are AUTO-GENERATED. Do NOT manually edit them.
-- `core/lib/`, `tools/sources/`, `generator/`, `examples/` are hand-written.
-- `tools/sources/` contains hand-crafted model overrides for polymorphic types — these overwrite generated files after generation.
-- Ensure dependency versions are consistent between `core/lib/Cargo.toml` and generated sub-crate `Cargo.toml` files.
-- Run `cargo fmt` and `cargo clippy` before committing.
+- `core/line_*/` crates (except `core/lib/`)
+  are AUTO-GENERATED. Do NOT manually edit them.
+- `core/lib/`, `tools/sources/`, `generator/`,
+  `examples/` are hand-written.
+- `tools/sources/` contains hand-crafted model
+  overrides for polymorphic types — these overwrite
+  generated files after generation.
+- Ensure dependency versions are consistent between
+  `core/lib/Cargo.toml` and generated sub-crate
+  `Cargo.toml` files.
+- Run `cargo fmt` and `cargo clippy`
+  before committing.
 
 ## Build Commands
 
@@ -45,5 +70,5 @@ cargo build              # Build workspace
 cargo test --tests       # Run tests
 cargo fmt                # Format
 cargo clippy             # Lint
-make generate            # Regenerate from line-openapi (requires Java)
+make generate            # Regenerate (requires Java)
 ```

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,49 @@
+# LINE Messaging API SDK for Rust
+
+## Rules
+
+- This is an OSS project. All code, comments, commit messages, and documentation MUST be in English.
+- License: Apache-2.0
+- Main branch: `develop`
+
+## Reference SDKs
+
+This SDK MUST follow the same architecture and patterns as the official LINE Bot SDKs:
+
+- **Java:** https://github.com/line/line-bot-sdk-java
+- **Python:** https://github.com/line/line-bot-sdk-python
+- **Go:** https://github.com/line/line-bot-sdk-go
+- **Node.js:** https://github.com/line/line-bot-sdk-nodejs
+- **PHP:** https://github.com/line/line-bot-sdk-php
+- **Ruby:** https://github.com/line/line-bot-sdk-ruby
+
+When in doubt about architecture, code generation approach, or project structure, refer to these repositories.
+
+## Key Patterns (shared across all official SDKs)
+
+1. **OpenAPI-driven code generation** — API clients and models are auto-generated from `line-openapi/` submodule YAML specs using a custom OpenAPI Generator plugin (Java/Maven).
+2. **`generate-code.py` orchestration** — A Python script drives the generation pipeline (most SDKs use this).
+3. **Custom templates (Pebble)** — Java, Go, Node.js, Ruby use Pebble templates for codegen customization.
+4. **Per-service module isolation** — Each LINE API surface is an independent module/crate.
+5. **Webhook = models only** — `webhook.yml` generates only model types, no API client.
+6. **Signature validation is hand-written** — HMAC-SHA256 verification of `x-line-signature`.
+7. **Generated code is committed** — Regenerated only when OpenAPI specs change.
+8. **Renovate bot** keeps `line-openapi` submodule up to date automatically.
+
+## Code Rules
+
+- `core/line_*/` crates (except `core/lib/`) are AUTO-GENERATED. Do NOT manually edit them.
+- `core/lib/`, `tools/sources/`, `generator/`, `examples/` are hand-written.
+- `tools/sources/` contains hand-crafted model overrides for polymorphic types — these overwrite generated files after generation.
+- Ensure dependency versions are consistent between `core/lib/Cargo.toml` and generated sub-crate `Cargo.toml` files.
+- Run `cargo fmt` and `cargo clippy` before committing.
+
+## Build Commands
+
+```bash
+cargo build              # Build workspace
+cargo test --tests       # Run tests
+cargo fmt                # Format
+cargo clippy             # Lint
+make generate            # Regenerate from line-openapi (requires Java)
+```


### PR DESCRIPTION
## Summary
- Add `.claude/CLAUDE.md` configuration file for Claude Code
- Define project rules, reference SDK links, and coding guidelines

## Details
Establishes Claude Code project context with:
- OSS rules (English only, Apache-2.0)
- Links to all 6 official LINE Bot SDK repositories as reference architecture
- Key patterns shared across official SDKs (OpenAPI codegen, per-service isolation, etc.)
- Code rules (generated vs hand-written boundaries, formatting)
- Build commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)