### PR TITLE
Switch line-openapi to official repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "line-openapi"]
 	path = line-openapi
-	url = git@github.com:nanato12/line-openapi.git
+	url = git@github.com:line/line-openapi.git


### PR DESCRIPTION
## Summary
- Switch `line-openapi` submodule from fork (`nanato12/line-openapi`) to official (`line/line-openapi`)
- Update to latest upstream commit (`17befb0`)

## Why
The fork was originally used because the official repo had slow updates.
This is no longer the case, so we switch to the official source.

## Note
Code regeneration (`make generate`) is needed as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)