### PR TITLE
Revert line-openapi submodule to nanato12 fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "line-openapi"]
 	path = line-openapi
-	url = git@github.com:line/line-openapi.git
+	url = git@github.com:nanato12/line-openapi.git


### PR DESCRIPTION
## Summary
- Revert submodule URL from `line/line-openapi` to `nanato12/line-openapi`
- Sync fork with upstream latest

## Why
The fork is needed to control version bumps in generated crate
`Cargo.toml` files before publishing to crates.io.
The fork has been synced with upstream (`line/line-openapi` main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)