### PR TITLE
Fix build errors after module regeneration

### DIFF
--- a/core/line_messaging_api/src/models/message.rs
+++ b/core/line_messaging_api/src/models/message.rs
@@ -15,6 +15,7 @@
 */
 
 use crate::models::audio_message::AudioMessage;
+use crate::models::coupon_message::CouponMessage;
 use crate::models::flex_message::FlexMessage;
 use crate::models::image_message::ImageMessage;
 use crate::models::imagemap_message::ImagemapMessage;
@@ -45,4 +46,6 @@ pub enum Message {
     Template(TemplateMessage),
     #[serde(rename = "flex")]
     Flex(FlexMessage),
+    #[serde(rename = "coupon")]
+    Coupon(CouponMessage),
 }

--- a/core/line_webhook/src/models/event.rs
+++ b/core/line_webhook/src/models/event.rs
@@ -17,8 +17,8 @@
 use super::{
     AccountLinkEvent, ActivatedEvent, BeaconEvent, BotResumedEvent, BotSuspendedEvent,
     DeactivatedEvent, FollowEvent, JoinEvent, LeaveEvent, MemberJoinedEvent, MemberLeftEvent,
-    MessageEvent, ModuleEvent, PostbackEvent, ThingsEvent, UnfollowEvent, UnsendEvent,
-    VideoPlayCompleteEvent,
+    MembershipEvent, MessageEvent, ModuleEvent, PnpDeliveryCompletionEvent, PostbackEvent,
+    UnfollowEvent, UnsendEvent, VideoPlayCompleteEvent,
 };
 
 /// Event : Webhook event
@@ -42,6 +42,8 @@ pub enum Event {
     MemberJoinedEvent(MemberJoinedEvent),
     #[serde(rename = "memberLeft")]
     MemberLeftEvent(MemberLeftEvent),
+    #[serde(rename = "membership")]
+    MembershipEvent(MembershipEvent),
     #[serde(rename = "postback")]
     PostbackEvent(PostbackEvent),
     #[serde(rename = "videoPlayComplete")]
@@ -50,8 +52,6 @@ pub enum Event {
     BeaconEvent(BeaconEvent),
     #[serde(rename = "accountLink")]
     AccountLinkEvent(AccountLinkEvent),
-    #[serde(rename = "things")]
-    ThingsEvent(ThingsEvent),
     #[serde(rename = "module")]
     ModuleEvent(ModuleEvent),
     #[serde(rename = "activated")]
@@ -62,4 +62,6 @@ pub enum Event {
     BotSuspendedEvent(BotSuspendedEvent),
     #[serde(rename = "botResumed")]
     BotResumedEvent(BotResumedEvent),
+    #[serde(rename = "delivery")]
+    PnpDeliveryCompletionEvent(PnpDeliveryCompletionEvent),
 }

--- a/tools/sources/messaging_api/src/models/message.rs
+++ b/tools/sources/messaging_api/src/models/message.rs
@@ -15,6 +15,7 @@
 */
 
 use crate::models::audio_message::AudioMessage;
+use crate::models::coupon_message::CouponMessage;
 use crate::models::flex_message::FlexMessage;
 use crate::models::image_message::ImageMessage;
 use crate::models::imagemap_message::ImagemapMessage;
@@ -45,4 +46,6 @@ pub enum Message {
     Template(TemplateMessage),
     #[serde(rename = "flex")]
     Flex(FlexMessage),
+    #[serde(rename = "coupon")]
+    Coupon(CouponMessage),
 }

--- a/tools/sources/webhook/src/models/event.rs
+++ b/tools/sources/webhook/src/models/event.rs
@@ -17,8 +17,8 @@
 use super::{
     AccountLinkEvent, ActivatedEvent, BeaconEvent, BotResumedEvent, BotSuspendedEvent,
     DeactivatedEvent, FollowEvent, JoinEvent, LeaveEvent, MemberJoinedEvent, MemberLeftEvent,
-    MessageEvent, ModuleEvent, PostbackEvent, ThingsEvent, UnfollowEvent, UnsendEvent,
-    VideoPlayCompleteEvent,
+    MembershipEvent, MessageEvent, ModuleEvent, PnpDeliveryCompletionEvent, PostbackEvent,
+    UnfollowEvent, UnsendEvent, VideoPlayCompleteEvent,
 };
 
 /// Event : Webhook event
@@ -42,6 +42,8 @@ pub enum Event {
     MemberJoinedEvent(MemberJoinedEvent),
     #[serde(rename = "memberLeft")]
     MemberLeftEvent(MemberLeftEvent),
+    #[serde(rename = "membership")]
+    MembershipEvent(MembershipEvent),
     #[serde(rename = "postback")]
     PostbackEvent(PostbackEvent),
     #[serde(rename = "videoPlayComplete")]
@@ -50,8 +52,6 @@ pub enum Event {
     BeaconEvent(BeaconEvent),
     #[serde(rename = "accountLink")]
     AccountLinkEvent(AccountLinkEvent),
-    #[serde(rename = "things")]
-    ThingsEvent(ThingsEvent),
     #[serde(rename = "module")]
     ModuleEvent(ModuleEvent),
     #[serde(rename = "activated")]
@@ -62,4 +62,6 @@ pub enum Event {
     BotSuspendedEvent(BotSuspendedEvent),
     #[serde(rename = "botResumed")]
     BotResumedEvent(BotResumedEvent),
+    #[serde(rename = "delivery")]
+    PnpDeliveryCompletionEvent(PnpDeliveryCompletionEvent),
 }


### PR DESCRIPTION
## Summary
- Update `Event` enum: remove `ThingsEvent` (deleted upstream),
  add `MembershipEvent` and `PnpDeliveryCompletionEvent`
- Update `Message` enum: add `CouponMessage`
- Update `tools/sources/` custom overrides accordingly

## Test plan
- [x] `cargo build` passes
- [x] `cargo test --tests` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)