### PR TITLE
Update dependency versions and document line-openapi

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -48,6 +48,19 @@ approach, or project structure, refer to these.
 8. **Renovate bot** keeps `line-openapi` submodule
    up to date automatically.
 
+## line-openapi Submodule
+
+- Uses a fork (`nanato12/line-openapi`), NOT the official
+  `line/line-openapi`.
+- Reason: `info.version` in each YAML spec controls the
+  generated crate version in `Cargo.toml`. The fork allows
+  bumping versions independently for crates.io publishing.
+- Upstream: <https://github.com/line/line-openapi>
+- Fork: <https://github.com/nanato12/line-openapi>
+- Sync fork before generation:
+  `gh repo sync nanato12/line-openapi --source line/line-openapi --branch main`
+- Submodule URL MUST use SSH (`git@github.com:`), not HTTPS.
+
 ## Code Rules
 
 - `core/line_*/` crates (except `core/lib/`)

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -16,19 +16,19 @@ rocket_support = ["rocket"]
 actix_support = ["actix-web"]
 
 [dependencies]
-base64 = "0.21.5"
+base64 = "0.22.1"
 hmac = "0.12.1"
 sha2 = "0.10.8"
 hyper = { version = "~0.14", features = ["full"] }
 hyper-rustls = "0.24.2"
 
 [dependencies.rocket]
-version = "0.5.0"
+version = "0.5.1"
 optional = true
 default-features = false
 
 [dependencies.actix-web]
-version = "4.4.0"
+version = "4.13.0"
 optional = true
 default-features = false
 

--- a/examples/actix_web_example/Cargo.toml
+++ b/examples/actix_web_example/Cargo.toml
@@ -6,10 +6,10 @@ workspace = "../"
 publish = false
 
 [dependencies]
-actix-rt = "2.9.0"
-actix-web = "4.4.0"
+actix-rt = "2.11.0"
+actix-web = "4.13.0"
 dotenv = "0.15.0"
-serde_json = "1.0.108"
+serde_json = "1.0.149"
 
 [dependencies.line-bot-sdk-rust]
 path = "../../core/lib"

--- a/examples/rocket_example/Cargo.toml
+++ b/examples/rocket_example/Cargo.toml
@@ -7,10 +7,10 @@ publish = false
 
 [dependencies]
 dotenv = "0.15.0"
-serde_json = "1.0.108"
+serde_json = "1.0.149"
 
 [dependencies.rocket]
-version = "0.5.0"
+version = "0.5.1"
 features = ["json"]
 
 [dependencies.line-bot-sdk-rust]


### PR DESCRIPTION
## Summary
- Update `base64` 0.21.5 -> 0.22.1 (API compatible for current usage)
- Update `rocket` 0.5.0 -> 0.5.1
- Update `actix-web` 4.4.0 -> 4.13.0
- Update `actix-rt` 2.9.0 -> 2.11.0
- Update `serde_json` 1.0.108 -> 1.0.149
- Add `line-openapi` submodule documentation to CLAUDE.md (fork reason, sync workflow, SSH requirement)

### Not included (separate work)
- `hyper` 0.14 -> 1.x (breaking: requires HTTP client rewrite)
- `hyper-rustls` 0.24 -> 0.27 (depends on hyper 1.x)
- Generated crate deps (`base64` 0.7, `serde_with` 2.x, `edition` 2018) — requires OpenAPI Generator template changes

## Test plan
- [x] `cargo build` passes
- [x] `cargo build` for examples passes
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)