### PR TITLE
Change generate workflow from auto-PR to diff check

### DIFF
--- a/.github/workflows/generate_modules.yml
+++ b/.github/workflows/generate_modules.yml
@@ -1,39 +1,37 @@
-name: Run generator
+name: Check generated modules
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/generate_modules.yml
+      - "line-openapi"
+      - "generator/**"
+      - "tools/**"
+      - "core/line_*/**"
   workflow_dispatch:
-  push:
-    branches:
-      - develop
-
-permissions:
-  contents: write
-  pull-requests: write
 
 jobs:
-  generate:
+  check-generate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: develop
           submodules: recursive
 
-      - name: update submodule
-        run: git submodule update --remote --recursive
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: generate line bot modules
+      - name: Run generator
         run: make generate
 
-      - uses: peter-evans/create-pull-request@v7
-        with:
-          commit-message: Generate LINEBot modules
-          delete-branch: true
-          title: Generate line bot modules
-          body: Auto generate line bot modules
-          reviewers: nanato12
-          assignees: octocat
-          labels: auto generate
+      - name: Check for uncommitted changes
+        run: |
+          if ! git diff --exit-code core/; then
+            echo "::error::Generated code is out of date. Run 'make generate' and commit the changes."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Replace the auto-generate + create-PR workflow with a CI check that verifies generated code is up to date
- Runs on PRs that touch `line-openapi`, `generator/`, `tools/`, or `core/line_*/`
- Fails if `make generate` produces any diff in `core/`, with a clear error message
- Adds Java 21 setup (required for openapi-generator-cli)
- Keeps `workflow_dispatch` for manual runs

### Before
- Push to develop → auto-generate → create PR (unreliable, caused build errors)

### After
- PR check → run generator → verify no diff (developer runs `make generate` locally before pushing)

## Test plan
- [ ] Verify workflow triggers on PRs touching relevant paths
- [ ] Verify `workflow_dispatch` still works for manual runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)