### PR TITLE
Fix outdated dependencies in generated code

### DIFF
--- a/core/lib/src/parser/signature.rs
+++ b/core/lib/src/parser/signature.rs
@@ -63,8 +63,7 @@ mod tests {
         type HmacSha256 = Hmac<Sha256>;
         let mut mac = HmacSha256::new_from_slice(channel_secret.as_bytes()).unwrap();
         mac.update(body.as_bytes());
-        let expected =
-            general_purpose::STANDARD.encode(mac.finalize().into_bytes());
+        let expected = general_purpose::STANDARD.encode(mac.finalize().into_bytes());
 
         assert!(validate_signature(channel_secret, &expected, body));
     }
@@ -80,7 +79,11 @@ mod tests {
 
     #[test]
     fn test_malformed_base64_signature() {
-        assert!(!validate_signature("test_secret", "not-valid-base64!!!", "body"));
+        assert!(!validate_signature(
+            "test_secret",
+            "not-valid-base64!!!",
+            "body"
+        ));
     }
 
     #[test]
@@ -91,8 +94,7 @@ mod tests {
         type HmacSha256 = Hmac<Sha256>;
         let mut mac = HmacSha256::new_from_slice(channel_secret.as_bytes()).unwrap();
         mac.update(body.as_bytes());
-        let expected =
-            general_purpose::STANDARD.encode(mac.finalize().into_bytes());
+        let expected = general_purpose::STANDARD.encode(mac.finalize().into_bytes());
 
         assert!(validate_signature(channel_secret, &expected, body));
     }

--- a/core/line_channel_access_token/Cargo.toml
+++ b/core/line_channel_access_token/Cargo.toml
@@ -15,6 +15,5 @@ url = "^2.5"
 hyper = { version = "^1.3.1", features = ["full"] }
 hyper-util = { version = "0.1.5", features = ["client", "client-legacy", "http1", "http2"] }
 http-body-util = { version = "0.1.2" }
-http = "~0.2"
-base64 = "~0.7.0"
+base64 = "0.22.1"
 futures = "^0.3"

--- a/core/line_channel_access_token/src/apis/request.rs
+++ b/core/line_channel_access_token/src/apis/request.rs
@@ -17,6 +17,7 @@
 use std::collections::HashMap;
 use std::pin::Pin;
 
+use base64::Engine as _;
 use futures;
 use futures::future::*;
 use futures::Future;
@@ -188,7 +189,7 @@ impl Request {
                     if let Some(ref pass) = auth_conf.1 {
                         text.push_str(&pass[..]);
                     }
-                    let encoded = base64::encode(&text);
+                    let encoded = base64::engine::general_purpose::STANDARD.encode(&text);
                     req_builder = req_builder.header(AUTHORIZATION, encoded);
                 }
             }

--- a/core/line_insight/Cargo.toml
+++ b/core/line_insight/Cargo.toml
@@ -16,6 +16,5 @@ url = "^2.5"
 hyper = { version = "^1.3.1", features = ["full"] }
 hyper-util = { version = "0.1.5", features = ["client", "client-legacy", "http1", "http2"] }
 http-body-util = { version = "0.1.2" }
-http = "~0.2"
-base64 = "~0.7.0"
+base64 = "0.22.1"
 futures = "^0.3"

--- a/core/line_insight/src/apis/request.rs
+++ b/core/line_insight/src/apis/request.rs
@@ -17,6 +17,7 @@
 use std::collections::HashMap;
 use std::pin::Pin;
 
+use base64::Engine as _;
 use futures;
 use futures::future::*;
 use futures::Future;
@@ -188,7 +189,7 @@ impl Request {
                     if let Some(ref pass) = auth_conf.1 {
                         text.push_str(&pass[..]);
                     }
-                    let encoded = base64::encode(&text);
+                    let encoded = base64::engine::general_purpose::STANDARD.encode(&text);
                     req_builder = req_builder.header(AUTHORIZATION, encoded);
                 }
             }

--- a/core/line_liff/Cargo.toml
+++ b/core/line_liff/Cargo.toml
@@ -15,6 +15,5 @@ url = "^2.5"
 hyper = { version = "^1.3.1", features = ["full"] }
 hyper-util = { version = "0.1.5", features = ["client", "client-legacy", "http1", "http2"] }
 http-body-util = { version = "0.1.2" }
-http = "~0.2"
-base64 = "~0.7.0"
+base64 = "0.22.1"
 futures = "^0.3"

--- a/core/line_liff/src/apis/request.rs
+++ b/core/line_liff/src/apis/request.rs
@@ -17,6 +17,7 @@
 use std::collections::HashMap;
 use std::pin::Pin;
 
+use base64::Engine as _;
 use futures;
 use futures::future::*;
 use futures::Future;
@@ -188,7 +189,7 @@ impl Request {
                     if let Some(ref pass) = auth_conf.1 {
                         text.push_str(&pass[..]);
                     }
-                    let encoded = base64::encode(&text);
+                    let encoded = base64::engine::general_purpose::STANDARD.encode(&text);
                     req_builder = req_builder.header(AUTHORIZATION, encoded);
                 }
             }

--- a/core/line_manage_audience/Cargo.toml
+++ b/core/line_manage_audience/Cargo.toml
@@ -16,6 +16,5 @@ url = "^2.5"
 hyper = { version = "^1.3.1", features = ["full"] }
 hyper-util = { version = "0.1.5", features = ["client", "client-legacy", "http1", "http2"] }
 http-body-util = { version = "0.1.2" }
-http = "~0.2"
-base64 = "~0.7.0"
+base64 = "0.22.1"
 futures = "^0.3"

--- a/core/line_manage_audience/src/apis/request.rs
+++ b/core/line_manage_audience/src/apis/request.rs
@@ -17,6 +17,7 @@
 use std::collections::HashMap;
 use std::pin::Pin;
 
+use base64::Engine as _;
 use futures;
 use futures::future::*;
 use futures::Future;
@@ -188,7 +189,7 @@ impl Request {
                     if let Some(ref pass) = auth_conf.1 {
                         text.push_str(&pass[..]);
                     }
-                    let encoded = base64::encode(&text);
+                    let encoded = base64::engine::general_purpose::STANDARD.encode(&text);
                     req_builder = req_builder.header(AUTHORIZATION, encoded);
                 }
             }

--- a/core/line_messaging_api/Cargo.toml
+++ b/core/line_messaging_api/Cargo.toml
@@ -16,6 +16,5 @@ uuid = { version = "^1.8", features = ["serde", "v4"] }
 hyper = { version = "^1.3.1", features = ["full"] }
 hyper-util = { version = "0.1.5", features = ["client", "client-legacy", "http1", "http2"] }
 http-body-util = { version = "0.1.2" }
-http = "~0.2"
-base64 = "~0.7.0"
+base64 = "0.22.1"
 futures = "^0.3"

--- a/core/line_messaging_api/src/apis/request.rs
+++ b/core/line_messaging_api/src/apis/request.rs
@@ -17,6 +17,7 @@
 use std::collections::HashMap;
 use std::pin::Pin;
 
+use base64::Engine as _;
 use futures;
 use futures::future::*;
 use futures::Future;
@@ -188,7 +189,7 @@ impl Request {
                     if let Some(ref pass) = auth_conf.1 {
                         text.push_str(&pass[..]);
                     }
-                    let encoded = base64::encode(&text);
+                    let encoded = base64::engine::general_purpose::STANDARD.encode(&text);
                     req_builder = req_builder.header(AUTHORIZATION, encoded);
                 }
             }

--- a/core/line_module/Cargo.toml
+++ b/core/line_module/Cargo.toml
@@ -15,6 +15,5 @@ url = "^2.5"
 hyper = { version = "^1.3.1", features = ["full"] }
 hyper-util = { version = "0.1.5", features = ["client", "client-legacy", "http1", "http2"] }
 http-body-util = { version = "0.1.2" }
-http = "~0.2"
-base64 = "~0.7.0"
+base64 = "0.22.1"
 futures = "^0.3"

--- a/core/line_module/src/apis/request.rs
+++ b/core/line_module/src/apis/request.rs
@@ -17,6 +17,7 @@
 use std::collections::HashMap;
 use std::pin::Pin;
 
+use base64::Engine as _;
 use futures;
 use futures::future::*;
 use futures::Future;
@@ -188,7 +189,7 @@ impl Request {
                     if let Some(ref pass) = auth_conf.1 {
                         text.push_str(&pass[..]);
                     }
-                    let encoded = base64::encode(&text);
+                    let encoded = base64::engine::general_purpose::STANDARD.encode(&text);
                     req_builder = req_builder.header(AUTHORIZATION, encoded);
                 }
             }

--- a/core/line_module_attach/Cargo.toml
+++ b/core/line_module_attach/Cargo.toml
@@ -15,6 +15,5 @@ url = "^2.5"
 hyper = { version = "^1.3.1", features = ["full"] }
 hyper-util = { version = "0.1.5", features = ["client", "client-legacy", "http1", "http2"] }
 http-body-util = { version = "0.1.2" }
-http = "~0.2"
-base64 = "~0.7.0"
+base64 = "0.22.1"
 futures = "^0.3"

--- a/core/line_module_attach/src/apis/request.rs
+++ b/core/line_module_attach/src/apis/request.rs
@@ -17,6 +17,7 @@
 use std::collections::HashMap;
 use std::pin::Pin;
 
+use base64::Engine as _;
 use futures;
 use futures::future::*;
 use futures::Future;
@@ -188,7 +189,7 @@ impl Request {
                     if let Some(ref pass) = auth_conf.1 {
                         text.push_str(&pass[..]);
                     }
-                    let encoded = base64::encode(&text);
+                    let encoded = base64::engine::general_purpose::STANDARD.encode(&text);
                     req_builder = req_builder.header(AUTHORIZATION, encoded);
                 }
             }

--- a/core/line_shop/Cargo.toml
+++ b/core/line_shop/Cargo.toml
@@ -15,6 +15,5 @@ url = "^2.5"
 hyper = { version = "^1.3.1", features = ["full"] }
 hyper-util = { version = "0.1.5", features = ["client", "client-legacy", "http1", "http2"] }
 http-body-util = { version = "0.1.2" }
-http = "~0.2"
-base64 = "~0.7.0"
+base64 = "0.22.1"
 futures = "^0.3"

--- a/core/line_shop/src/apis/request.rs
+++ b/core/line_shop/src/apis/request.rs
@@ -17,6 +17,7 @@
 use std::collections::HashMap;
 use std::pin::Pin;
 
+use base64::Engine as _;
 use futures;
 use futures::future::*;
 use futures::Future;
@@ -188,7 +189,7 @@ impl Request {
                     if let Some(ref pass) = auth_conf.1 {
                         text.push_str(&pass[..]);
                     }
-                    let encoded = base64::encode(&text);
+                    let encoded = base64::engine::general_purpose::STANDARD.encode(&text);
                     req_builder = req_builder.header(AUTHORIZATION, encoded);
                 }
             }

--- a/core/line_webhook/Cargo.toml
+++ b/core/line_webhook/Cargo.toml
@@ -15,6 +15,5 @@ url = "^2.5"
 hyper = { version = "^1.3.1", features = ["full"] }
 hyper-util = { version = "0.1.5", features = ["client", "client-legacy", "http1", "http2"] }
 http-body-util = { version = "0.1.2" }
-http = "~0.2"
-base64 = "~0.7.0"
+base64 = "0.22.1"
 futures = "^0.3"

--- a/core/line_webhook/src/apis/request.rs
+++ b/core/line_webhook/src/apis/request.rs
@@ -17,6 +17,7 @@
 use std::collections::HashMap;
 use std::pin::Pin;
 
+use base64::Engine as _;
 use futures;
 use futures::future::*;
 use futures::Future;
@@ -188,7 +189,7 @@ impl Request {
                     if let Some(ref pass) = auth_conf.1 {
                         text.push_str(&pass[..]);
                     }
-                    let encoded = base64::encode(&text);
+                    let encoded = base64::engine::general_purpose::STANDARD.encode(&text);
                     req_builder = req_builder.header(AUTHORIZATION, encoded);
                 }
             }

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -121,6 +121,39 @@ fn fix_openapi_messaging_api(file_path: &Path) {
     replace_in_file(file_path, replacements);
 }
 
+fn fix_generated_dependencies(pkg_dir: &str) {
+    let cargo_toml_path = Path::new(pkg_dir).join("Cargo.toml");
+    let replacements: HashMap<&str, &str> = [
+        // Remove unused http crate (hyper 1.x re-exports http types via hyper::http)
+        ("http = \"~0.2\"\n", ""),
+        // Update base64 from 0.7 to 0.22
+        ("base64 = \"~0.7.0\"", "base64 = \"0.22.1\""),
+    ]
+    .iter()
+    .cloned()
+    .collect();
+    replace_in_file(&cargo_toml_path, replacements);
+
+    // Update base64 API usage in request.rs (0.7 -> 0.22)
+    let request_rs_path = Path::new(pkg_dir).join("src/apis/request.rs");
+    if request_rs_path.exists() {
+        let replacements: HashMap<&str, &str> = [
+            (
+                "use http_body_util::BodyExt;",
+                "use base64::Engine as _;\nuse http_body_util::BodyExt;",
+            ),
+            (
+                "let encoded = base64::encode(&text);",
+                "let encoded = base64::engine::general_purpose::STANDARD.encode(&text);",
+            ),
+        ]
+        .iter()
+        .cloned()
+        .collect();
+        replace_in_file(&request_rs_path, replacements);
+    }
+}
+
 fn process_directory(dir_path: &PathBuf, pkg_name: &str) {
     if let Ok(entries) = fs::read_dir(dir_path) {
         for entry in entries {
@@ -238,7 +271,8 @@ fn main() {
             continue;
         }
 
-        process_directory(&PathBuf::from(pkg_dir), pkg_name)
+        process_directory(&PathBuf::from(pkg_dir), pkg_name);
+        fix_generated_dependencies(pkg_dir);
     }
 
     let sources = vec![


### PR DESCRIPTION
## Summary
- Remove unused `http = "~0.2"` from all generated `Cargo.toml` (hyper 1.x re-exports http types via `hyper::http`)
- Update `base64` from `"~0.7.0"` (2017) to `"0.22.1"` in all generated modules
- Update `base64::encode()` (0.7 API) to `base64::engine::general_purpose::STANDARD.encode()` (0.22 API)

## How
Added `fix_generated_dependencies()` post-processing step in `generator/src/main.rs` that runs after each module is generated, fixing Cargo.toml versions and request.rs API usage.

## Impact
- Eliminates duplicate `base64` versions (0.7 + 0.22) in the dependency tree
- Removes unused `http 0.2` crate from dependency tree
- All 9 generated modules + `core/lib` now use `base64 = "0.22.1"` consistently

Closes #78

## Test plan
- [x] `make generate` succeeds
- [x] `cargo build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)