### PR TITLE
Implement Display and Error traits for generated Error types

### DIFF
--- a/core/line_channel_access_token/src/apis/mod.rs
+++ b/core/line_channel_access_token/src/apis/mod.rs
@@ -56,6 +56,34 @@ impl From<(hyper::StatusCode, hyper::body::Incoming)> for Error {
     }
 }
 
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Api(e) => write!(f, "API error (status {})", e.code),
+            Error::Header(e) => write!(f, "invalid header: {}", e),
+            Error::Http(e) => write!(f, "HTTP error: {}", e),
+            Error::Hyper(e) => write!(f, "hyper error: {}", e),
+            Error::HyperClient(e) => write!(f, "hyper client error: {}", e),
+            Error::Serde(e) => write!(f, "serde error: {}", e),
+            Error::UriError(e) => write!(f, "URI error: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Header(e) => Some(e),
+            Error::Http(e) => Some(e),
+            Error::Hyper(e) => Some(e),
+            Error::HyperClient(e) => Some(e),
+            Error::Serde(e) => Some(e),
+            Error::UriError(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
 impl From<http::Error> for Error {
     fn from(e: http::Error) -> Self {
         Error::Http(e)

--- a/core/line_insight/src/apis/mod.rs
+++ b/core/line_insight/src/apis/mod.rs
@@ -56,6 +56,34 @@ impl From<(hyper::StatusCode, hyper::body::Incoming)> for Error {
     }
 }
 
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Api(e) => write!(f, "API error (status {})", e.code),
+            Error::Header(e) => write!(f, "invalid header: {}", e),
+            Error::Http(e) => write!(f, "HTTP error: {}", e),
+            Error::Hyper(e) => write!(f, "hyper error: {}", e),
+            Error::HyperClient(e) => write!(f, "hyper client error: {}", e),
+            Error::Serde(e) => write!(f, "serde error: {}", e),
+            Error::UriError(e) => write!(f, "URI error: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Header(e) => Some(e),
+            Error::Http(e) => Some(e),
+            Error::Hyper(e) => Some(e),
+            Error::HyperClient(e) => Some(e),
+            Error::Serde(e) => Some(e),
+            Error::UriError(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
 impl From<http::Error> for Error {
     fn from(e: http::Error) -> Self {
         Error::Http(e)

--- a/core/line_liff/src/apis/mod.rs
+++ b/core/line_liff/src/apis/mod.rs
@@ -56,6 +56,34 @@ impl From<(hyper::StatusCode, hyper::body::Incoming)> for Error {
     }
 }
 
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Api(e) => write!(f, "API error (status {})", e.code),
+            Error::Header(e) => write!(f, "invalid header: {}", e),
+            Error::Http(e) => write!(f, "HTTP error: {}", e),
+            Error::Hyper(e) => write!(f, "hyper error: {}", e),
+            Error::HyperClient(e) => write!(f, "hyper client error: {}", e),
+            Error::Serde(e) => write!(f, "serde error: {}", e),
+            Error::UriError(e) => write!(f, "URI error: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Header(e) => Some(e),
+            Error::Http(e) => Some(e),
+            Error::Hyper(e) => Some(e),
+            Error::HyperClient(e) => Some(e),
+            Error::Serde(e) => Some(e),
+            Error::UriError(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
 impl From<http::Error> for Error {
     fn from(e: http::Error) -> Self {
         Error::Http(e)

--- a/core/line_manage_audience/src/apis/mod.rs
+++ b/core/line_manage_audience/src/apis/mod.rs
@@ -56,6 +56,34 @@ impl From<(hyper::StatusCode, hyper::body::Incoming)> for Error {
     }
 }
 
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Api(e) => write!(f, "API error (status {})", e.code),
+            Error::Header(e) => write!(f, "invalid header: {}", e),
+            Error::Http(e) => write!(f, "HTTP error: {}", e),
+            Error::Hyper(e) => write!(f, "hyper error: {}", e),
+            Error::HyperClient(e) => write!(f, "hyper client error: {}", e),
+            Error::Serde(e) => write!(f, "serde error: {}", e),
+            Error::UriError(e) => write!(f, "URI error: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Header(e) => Some(e),
+            Error::Http(e) => Some(e),
+            Error::Hyper(e) => Some(e),
+            Error::HyperClient(e) => Some(e),
+            Error::Serde(e) => Some(e),
+            Error::UriError(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
 impl From<http::Error> for Error {
     fn from(e: http::Error) -> Self {
         Error::Http(e)

--- a/core/line_messaging_api/src/apis/mod.rs
+++ b/core/line_messaging_api/src/apis/mod.rs
@@ -56,6 +56,34 @@ impl From<(hyper::StatusCode, hyper::body::Incoming)> for Error {
     }
 }
 
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Api(e) => write!(f, "API error (status {})", e.code),
+            Error::Header(e) => write!(f, "invalid header: {}", e),
+            Error::Http(e) => write!(f, "HTTP error: {}", e),
+            Error::Hyper(e) => write!(f, "hyper error: {}", e),
+            Error::HyperClient(e) => write!(f, "hyper client error: {}", e),
+            Error::Serde(e) => write!(f, "serde error: {}", e),
+            Error::UriError(e) => write!(f, "URI error: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Header(e) => Some(e),
+            Error::Http(e) => Some(e),
+            Error::Hyper(e) => Some(e),
+            Error::HyperClient(e) => Some(e),
+            Error::Serde(e) => Some(e),
+            Error::UriError(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
 impl From<http::Error> for Error {
     fn from(e: http::Error) -> Self {
         Error::Http(e)

--- a/core/line_module/src/apis/mod.rs
+++ b/core/line_module/src/apis/mod.rs
@@ -56,6 +56,34 @@ impl From<(hyper::StatusCode, hyper::body::Incoming)> for Error {
     }
 }
 
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Api(e) => write!(f, "API error (status {})", e.code),
+            Error::Header(e) => write!(f, "invalid header: {}", e),
+            Error::Http(e) => write!(f, "HTTP error: {}", e),
+            Error::Hyper(e) => write!(f, "hyper error: {}", e),
+            Error::HyperClient(e) => write!(f, "hyper client error: {}", e),
+            Error::Serde(e) => write!(f, "serde error: {}", e),
+            Error::UriError(e) => write!(f, "URI error: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Header(e) => Some(e),
+            Error::Http(e) => Some(e),
+            Error::Hyper(e) => Some(e),
+            Error::HyperClient(e) => Some(e),
+            Error::Serde(e) => Some(e),
+            Error::UriError(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
 impl From<http::Error> for Error {
     fn from(e: http::Error) -> Self {
         Error::Http(e)

--- a/core/line_module_attach/src/apis/mod.rs
+++ b/core/line_module_attach/src/apis/mod.rs
@@ -56,6 +56,34 @@ impl From<(hyper::StatusCode, hyper::body::Incoming)> for Error {
     }
 }
 
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Api(e) => write!(f, "API error (status {})", e.code),
+            Error::Header(e) => write!(f, "invalid header: {}", e),
+            Error::Http(e) => write!(f, "HTTP error: {}", e),
+            Error::Hyper(e) => write!(f, "hyper error: {}", e),
+            Error::HyperClient(e) => write!(f, "hyper client error: {}", e),
+            Error::Serde(e) => write!(f, "serde error: {}", e),
+            Error::UriError(e) => write!(f, "URI error: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Header(e) => Some(e),
+            Error::Http(e) => Some(e),
+            Error::Hyper(e) => Some(e),
+            Error::HyperClient(e) => Some(e),
+            Error::Serde(e) => Some(e),
+            Error::UriError(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
 impl From<http::Error> for Error {
     fn from(e: http::Error) -> Self {
         Error::Http(e)

--- a/core/line_shop/src/apis/mod.rs
+++ b/core/line_shop/src/apis/mod.rs
@@ -56,6 +56,34 @@ impl From<(hyper::StatusCode, hyper::body::Incoming)> for Error {
     }
 }
 
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Api(e) => write!(f, "API error (status {})", e.code),
+            Error::Header(e) => write!(f, "invalid header: {}", e),
+            Error::Http(e) => write!(f, "HTTP error: {}", e),
+            Error::Hyper(e) => write!(f, "hyper error: {}", e),
+            Error::HyperClient(e) => write!(f, "hyper client error: {}", e),
+            Error::Serde(e) => write!(f, "serde error: {}", e),
+            Error::UriError(e) => write!(f, "URI error: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Header(e) => Some(e),
+            Error::Http(e) => Some(e),
+            Error::Hyper(e) => Some(e),
+            Error::HyperClient(e) => Some(e),
+            Error::Serde(e) => Some(e),
+            Error::UriError(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
 impl From<http::Error> for Error {
     fn from(e: http::Error) -> Self {
         Error::Http(e)

--- a/core/line_webhook/src/apis/mod.rs
+++ b/core/line_webhook/src/apis/mod.rs
@@ -56,6 +56,34 @@ impl From<(hyper::StatusCode, hyper::body::Incoming)> for Error {
     }
 }
 
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Api(e) => write!(f, "API error (status {})", e.code),
+            Error::Header(e) => write!(f, "invalid header: {}", e),
+            Error::Http(e) => write!(f, "HTTP error: {}", e),
+            Error::Hyper(e) => write!(f, "hyper error: {}", e),
+            Error::HyperClient(e) => write!(f, "hyper client error: {}", e),
+            Error::Serde(e) => write!(f, "serde error: {}", e),
+            Error::UriError(e) => write!(f, "URI error: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Header(e) => Some(e),
+            Error::Http(e) => Some(e),
+            Error::Hyper(e) => Some(e),
+            Error::HyperClient(e) => Some(e),
+            Error::Serde(e) => Some(e),
+            Error::UriError(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
 impl From<http::Error> for Error {
     fn from(e: http::Error) -> Self {
         Error::Http(e)

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -154,6 +154,60 @@ fn fix_generated_dependencies(pkg_dir: &str) {
     }
 }
 
+fn fix_error_type(pkg_dir: &str) {
+    let mod_rs_path = Path::new(pkg_dir).join("src/apis/mod.rs");
+    if !mod_rs_path.exists() {
+        return;
+    }
+
+    let mut file = File::open(&mod_rs_path).unwrap();
+    let mut contents = String::new();
+    file.read_to_string(&mut contents).unwrap();
+
+    // Skip if already patched
+    if contents.contains("impl fmt::Display for Error") {
+        return;
+    }
+
+    let impls = r#"impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Api(e) => write!(f, "API error (status {})", e.code),
+            Error::Header(e) => write!(f, "invalid header: {}", e),
+            Error::Http(e) => write!(f, "HTTP error: {}", e),
+            Error::Hyper(e) => write!(f, "hyper error: {}", e),
+            Error::HyperClient(e) => write!(f, "hyper client error: {}", e),
+            Error::Serde(e) => write!(f, "serde error: {}", e),
+            Error::UriError(e) => write!(f, "URI error: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Header(e) => Some(e),
+            Error::Http(e) => Some(e),
+            Error::Hyper(e) => Some(e),
+            Error::HyperClient(e) => Some(e),
+            Error::Serde(e) => Some(e),
+            Error::UriError(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+"#;
+
+    contents = contents.replace(
+        "impl From<http::Error> for Error {",
+        &format!("{impls}impl From<http::Error> for Error {{"),
+    );
+
+    let mut file = File::create(&mod_rs_path).unwrap();
+    file.write_all(contents.as_bytes()).unwrap();
+}
+
 fn process_directory(dir_path: &PathBuf, pkg_name: &str) {
     if let Ok(entries) = fs::read_dir(dir_path) {
         for entry in entries {
@@ -273,6 +327,7 @@ fn main() {
 
         process_directory(&PathBuf::from(pkg_dir), pkg_name);
         fix_generated_dependencies(pkg_dir);
+        fix_error_type(pkg_dir);
     }
 
     let sources = vec![


### PR DESCRIPTION
## Summary
- Add `fmt::Display` implementation to the generated `Error` enum in all 9 modules
- Add `std::error::Error` implementation with `source()` for error chaining
- Injected via `fix_error_type()` post-processing step in generator

## Before
```rust
// Only Debug was implemented - incompatible with ?, anyhow, eyre
#[derive(Debug)]
pub enum Error { ... }
```

## After
```rust
impl fmt::Display for Error {
    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
        match self {
            Error::Api(e) => write!(f, "API error (status {})", e.code),
            Error::Header(e) => write!(f, "invalid header: {}", e),
            // ...
        }
    }
}

impl std::error::Error for Error {
    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { ... }
}
```

## Impact
Users can now use `?` with the SDK's error types in functions returning `Box<dyn std::error::Error>`, `anyhow::Result`, etc.

Closes #79

## Test plan
- [x] `make generate` succeeds
- [x] `cargo build` succeeds
- [x] All 9 modules have both impls

🤖 Generated with [Claude Code](https://claude.com/claude-code)