### PR TITLE
Improve LINE client struct

### DIFF
--- a/core/lib/src/client/mod.rs
+++ b/core/lib/src/client/mod.rs
@@ -28,9 +28,11 @@ use line_insight::apis::{configuration::Configuration as InsightConfiguration, I
 use line_liff::apis::{configuration::Configuration as LiffConfiguration, LiffApiClient};
 use line_manage_audience::apis::{
     configuration::Configuration as ManageAudienceConfiguration, ManageAudienceApiClient,
+    ManageAudienceBlobApiClient,
 };
 use line_messaging_api::apis::{
     configuration::Configuration as MessagingApiConfiguration, MessagingApiApiClient,
+    MessagingApiBlobApiClient,
 };
 use line_module::apis::{
     configuration::Configuration as LineModuleConfiguration, LineModuleApiClient,
@@ -43,18 +45,21 @@ use line_webhook::apis::{
     configuration::Configuration as WebhookConfiguration, DummyApiClient as WebhookDummyApiClient,
 };
 
-type C = HttpsConnector<HttpConnector>;
+type HttpsClient = HttpsConnector<HttpConnector>;
 
+#[derive(Clone)]
 pub struct LINE {
-    pub channel_access_token_api_client: ChannelAccessTokenApiClient<C>,
-    pub insight_api_client: InsightApiClient<C>,
-    pub liff_api_client: LiffApiClient<C>,
-    pub manage_audience_api_client: ManageAudienceApiClient<C>,
-    pub messaging_api_client: MessagingApiApiClient<C>,
-    pub module_api_client: LineModuleApiClient<C>,
-    pub module_attach_api_client: LineModuleAttachApiClient<C>,
-    pub shop_api_client: ShopApiClient<C>,
-    pub webhook_dummy_api_client: WebhookDummyApiClient<C>,
+    pub channel_access_token_api_client: ChannelAccessTokenApiClient<HttpsClient>,
+    pub insight_api_client: InsightApiClient<HttpsClient>,
+    pub liff_api_client: LiffApiClient<HttpsClient>,
+    pub manage_audience_api_client: ManageAudienceApiClient<HttpsClient>,
+    pub manage_audience_blob_api_client: ManageAudienceBlobApiClient<HttpsClient>,
+    pub messaging_api_client: MessagingApiApiClient<HttpsClient>,
+    pub messaging_api_blob_client: MessagingApiBlobApiClient<HttpsClient>,
+    pub module_api_client: LineModuleApiClient<HttpsClient>,
+    pub module_attach_api_client: LineModuleAttachApiClient<HttpsClient>,
+    pub shop_api_client: ShopApiClient<HttpsClient>,
+    pub webhook_dummy_api_client: WebhookDummyApiClient<HttpsClient>,
 }
 
 impl LINE {
@@ -84,10 +89,23 @@ impl LINE {
         let manage_audience_api_client =
             ManageAudienceApiClient::new(Arc::new(manage_audience_conf));
 
+        // manage_audience_blob
+        let mut manage_audience_blob_conf =
+            ManageAudienceConfiguration::with_client(client.clone());
+        manage_audience_blob_conf.oauth_access_token = Some(token.to_owned());
+        let manage_audience_blob_api_client =
+            ManageAudienceBlobApiClient::new(Arc::new(manage_audience_blob_conf));
+
         // messaging_api
         let mut messaging_api_conf = MessagingApiConfiguration::with_client(client.clone());
         messaging_api_conf.oauth_access_token = Some(token.to_owned());
         let messaging_api_client = MessagingApiApiClient::new(Arc::new(messaging_api_conf));
+
+        // messaging_api_blob
+        let mut messaging_api_blob_conf = MessagingApiConfiguration::with_client(client.clone());
+        messaging_api_blob_conf.oauth_access_token = Some(token.to_owned());
+        let messaging_api_blob_client =
+            MessagingApiBlobApiClient::new(Arc::new(messaging_api_blob_conf));
 
         // module
         let mut module_conf = LineModuleConfiguration::with_client(client.clone());
@@ -114,7 +132,9 @@ impl LINE {
             insight_api_client,
             liff_api_client,
             manage_audience_api_client,
+            manage_audience_blob_api_client,
             messaging_api_client,
+            messaging_api_blob_client,
             module_api_client,
             module_attach_api_client,
             shop_api_client,
@@ -122,7 +142,7 @@ impl LINE {
         }
     }
 
-    fn create_hyper_client() -> Client<C, String> {
+    fn create_hyper_client() -> Client<HttpsClient, String> {
         let https = HttpsConnectorBuilder::new()
             .with_native_roots()
             .expect("no native root certs found")

--- a/core/line_channel_access_token/src/apis/channel_access_token_api.rs
+++ b/core/line_channel_access_token/src/apis/channel_access_token_api.rs
@@ -38,6 +38,7 @@ use super::request as __internal_request;
 use super::{configuration, Error};
 use crate::models;
 
+#[derive(Clone)]
 pub struct ChannelAccessTokenApiClient<C: Connect>
 where
     C: Clone + std::marker::Send + Sync + 'static,

--- a/core/line_insight/src/apis/insight_api.rs
+++ b/core/line_insight/src/apis/insight_api.rs
@@ -38,6 +38,7 @@ use super::request as __internal_request;
 use super::{configuration, Error};
 use crate::models;
 
+#[derive(Clone)]
 pub struct InsightApiClient<C: Connect>
 where
     C: Clone + std::marker::Send + Sync + 'static,

--- a/core/line_liff/src/apis/liff_api.rs
+++ b/core/line_liff/src/apis/liff_api.rs
@@ -38,6 +38,7 @@ use super::request as __internal_request;
 use super::{configuration, Error};
 use crate::models;
 
+#[derive(Clone)]
 pub struct LiffApiClient<C: Connect>
 where
     C: Clone + std::marker::Send + Sync + 'static,

--- a/core/line_manage_audience/src/apis/manage_audience_api.rs
+++ b/core/line_manage_audience/src/apis/manage_audience_api.rs
@@ -38,6 +38,7 @@ use super::request as __internal_request;
 use super::{configuration, Error};
 use crate::models;
 
+#[derive(Clone)]
 pub struct ManageAudienceApiClient<C: Connect>
 where
     C: Clone + std::marker::Send + Sync + 'static,

--- a/core/line_manage_audience/src/apis/manage_audience_blob_api.rs
+++ b/core/line_manage_audience/src/apis/manage_audience_blob_api.rs
@@ -38,6 +38,7 @@ use super::request as __internal_request;
 use super::{configuration, Error};
 use crate::models;
 
+#[derive(Clone)]
 pub struct ManageAudienceBlobApiClient<C: Connect>
 where
     C: Clone + std::marker::Send + Sync + 'static,

--- a/core/line_messaging_api/src/apis/messaging_api_api.rs
+++ b/core/line_messaging_api/src/apis/messaging_api_api.rs
@@ -38,6 +38,7 @@ use super::request as __internal_request;
 use super::{configuration, Error};
 use crate::models;
 
+#[derive(Clone)]
 pub struct MessagingApiApiClient<C: Connect>
 where
     C: Clone + std::marker::Send + Sync + 'static,

--- a/core/line_messaging_api/src/apis/messaging_api_blob_api.rs
+++ b/core/line_messaging_api/src/apis/messaging_api_blob_api.rs
@@ -38,6 +38,7 @@ use super::request as __internal_request;
 use super::{configuration, Error};
 use crate::models;
 
+#[derive(Clone)]
 pub struct MessagingApiBlobApiClient<C: Connect>
 where
     C: Clone + std::marker::Send + Sync + 'static,

--- a/core/line_module/src/apis/line_module_api.rs
+++ b/core/line_module/src/apis/line_module_api.rs
@@ -38,6 +38,7 @@ use super::request as __internal_request;
 use super::{configuration, Error};
 use crate::models;
 
+#[derive(Clone)]
 pub struct LineModuleApiClient<C: Connect>
 where
     C: Clone + std::marker::Send + Sync + 'static,

--- a/core/line_module_attach/src/apis/line_module_attach_api.rs
+++ b/core/line_module_attach/src/apis/line_module_attach_api.rs
@@ -38,6 +38,7 @@ use super::request as __internal_request;
 use super::{configuration, Error};
 use crate::models;
 
+#[derive(Clone)]
 pub struct LineModuleAttachApiClient<C: Connect>
 where
     C: Clone + std::marker::Send + Sync + 'static,

--- a/core/line_shop/src/apis/shop_api.rs
+++ b/core/line_shop/src/apis/shop_api.rs
@@ -38,6 +38,7 @@ use super::request as __internal_request;
 use super::{configuration, Error};
 use crate::models;
 
+#[derive(Clone)]
 pub struct ShopApiClient<C: Connect>
 where
     C: Clone + std::marker::Send + Sync + 'static,

--- a/core/line_webhook/src/apis/dummy_api.rs
+++ b/core/line_webhook/src/apis/dummy_api.rs
@@ -38,6 +38,7 @@ use super::request as __internal_request;
 use super::{configuration, Error};
 use crate::models;
 
+#[derive(Clone)]
 pub struct DummyApiClient<C: Connect>
 where
     C: Clone + std::marker::Send + Sync + 'static,

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -208,6 +208,40 @@ impl std::error::Error for Error {
     file.write_all(contents.as_bytes()).unwrap();
 }
 
+fn fix_api_client_clone(pkg_dir: &str) {
+    let apis_dir = Path::new(pkg_dir).join("src/apis");
+    if !apis_dir.exists() {
+        return;
+    }
+
+    if let Ok(entries) = fs::read_dir(&apis_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().map_or(true, |e| e != "rs") {
+                continue;
+            }
+
+            let mut file = File::open(&path).unwrap();
+            let mut contents = String::new();
+            file.read_to_string(&mut contents).unwrap();
+
+            if !contents.contains("pub struct ") || !contents.contains("ApiClient<C: Connect>") {
+                continue;
+            }
+
+            // Skip if already patched
+            if contents.contains("#[derive(Clone)]") {
+                continue;
+            }
+
+            contents = contents.replace("pub struct ", "#[derive(Clone)]\npub struct ");
+
+            let mut file = File::create(&path).unwrap();
+            file.write_all(contents.as_bytes()).unwrap();
+        }
+    }
+}
+
 fn process_directory(dir_path: &PathBuf, pkg_name: &str) {
     if let Ok(entries) = fs::read_dir(dir_path) {
         for entry in entries {
@@ -328,6 +362,7 @@ fn main() {
         process_directory(&PathBuf::from(pkg_dir), pkg_name);
         fix_generated_dependencies(pkg_dir);
         fix_error_type(pkg_dir);
+        fix_api_client_clone(pkg_dir);
     }
 
     let sources = vec![


### PR DESCRIPTION
## Summary
- Add `#[derive(Clone)]` to `LINE` struct and all generated API client structs, enabling easy sharing across async tasks
- Add missing `ManageAudienceBlobApiClient` and `MessagingApiBlobApiClient` fields to expose Blob APIs
- Rename type alias `C` → `HttpsClient` for better readability
- Add `fix_api_client_clone()` generator post-processing to inject `Clone` derive on generated client structs

closes #80

## Test plan
- [x] `cargo build` succeeds
- [x] `cargo test` passes (25 tests)
- [x] `make generate` is idempotent (re-running produces no diff)
- [x] Examples build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)