### PR TITLE
Deduplicate workspace dependencies and clean up examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,15 @@ members = [
 ]
 
 [workspace.dependencies]
-serde = { version = "^1.0", features = ["derive"] }
+serde = "^1.0"
 serde_json = "^1.0"
 serde_repr = "^0.1"
-serde_with = { version = "^3.8", default-features = false, features = ["base64", "std", "macros"] }
+serde_with = "^3.8"
 url = "^2.5"
-uuid = { version = "^1.8", features = ["serde", "v4"] }
-hyper = { version = "^1.3.1", features = ["full"] }
-hyper-util = { version = "0.1.5", features = ["client", "client-legacy", "http1", "http2"] }
-hyper-rustls = { version = "0.27", features = ["native-tokio", "http1", "http2"] }
+uuid = "^1.8"
+hyper = "^1.3.1"
+hyper-util = "0.1.5"
+hyper-rustls = "0.27"
 http-body-util = "0.1.2"
 base64 = "0.22.1"
 futures = "^0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,19 @@ members = [
     "core/line_shop",
     "core/line_webhook",
 ]
+
+[workspace.dependencies]
+serde = { version = "^1.0", features = ["derive"] }
+serde_json = "^1.0"
+serde_repr = "^0.1"
+serde_with = { version = "^3.8", default-features = false, features = ["base64", "std", "macros"] }
+url = "^2.5"
+uuid = { version = "^1.8", features = ["serde", "v4"] }
+hyper = { version = "^1.3.1", features = ["full"] }
+hyper-util = { version = "0.1.5", features = ["client", "client-legacy", "http1", "http2"] }
+hyper-rustls = { version = "0.27", features = ["native-tokio", "http1", "http2"] }
+http-body-util = "0.1.2"
+base64 = "0.22.1"
+futures = "^0.3"
+hmac = "0.12.1"
+sha2 = "0.10.8"

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -16,12 +16,12 @@ rocket_support = ["rocket"]
 actix_support = ["actix-web"]
 
 [dependencies]
-base64 = "0.22.1"
-hmac = "0.12.1"
-sha2 = "0.10.8"
-hyper = { version = "^1.3.1", features = ["full"] }
-hyper-util = { version = "0.1.5", features = ["client", "client-legacy", "http1", "http2"] }
-hyper-rustls = { version = "0.27", features = ["native-tokio", "http1", "http2"] }
+base64.workspace = true
+hmac.workspace = true
+sha2.workspace = true
+hyper = { workspace = true, features = ["full"] }
+hyper-util = { workspace = true, features = ["client", "client-legacy", "http1", "http2"] }
+hyper-rustls = { workspace = true, features = ["native-tokio", "http1", "http2"] }
 
 [dependencies.rocket]
 version = "0.5.1"

--- a/core/line_channel_access_token/Cargo.toml
+++ b/core/line_channel_access_token/Cargo.toml
@@ -8,12 +8,12 @@ license = "Unlicense"
 edition = "2021"
 
 [dependencies]
-serde = { version = "^1.0", features = ["derive"] }
-serde_json = "^1.0"
-serde_repr = "^0.1"
-url = "^2.5"
-hyper = { version = "^1.3.1", features = ["full"] }
-hyper-util = { version = "0.1.5", features = ["client", "client-legacy", "http1", "http2"] }
-http-body-util = { version = "0.1.2" }
-base64 = "0.22.1"
-futures = "^0.3"
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+serde_repr.workspace = true
+url.workspace = true
+hyper = { workspace = true, features = ["full"] }
+hyper-util = { workspace = true, features = ["client", "client-legacy", "http1", "http2"] }
+http-body-util.workspace = true
+base64.workspace = true
+futures.workspace = true

--- a/core/line_insight/Cargo.toml
+++ b/core/line_insight/Cargo.toml
@@ -8,13 +8,13 @@ license = "Unlicense"
 edition = "2021"
 
 [dependencies]
-serde = { version = "^1.0", features = ["derive"] }
-serde_with = { version = "^3.8", default-features = false, features = ["base64", "std", "macros"] }
-serde_json = "^1.0"
-serde_repr = "^0.1"
-url = "^2.5"
-hyper = { version = "^1.3.1", features = ["full"] }
-hyper-util = { version = "0.1.5", features = ["client", "client-legacy", "http1", "http2"] }
-http-body-util = { version = "0.1.2" }
-base64 = "0.22.1"
-futures = "^0.3"
+serde = { workspace = true, features = ["derive"] }
+serde_with = { workspace = true, default-features = false, features = ["base64", "std", "macros"] }
+serde_json.workspace = true
+serde_repr.workspace = true
+url.workspace = true
+hyper = { workspace = true, features = ["full"] }
+hyper-util = { workspace = true, features = ["client", "client-legacy", "http1", "http2"] }
+http-body-util.workspace = true
+base64.workspace = true
+futures.workspace = true

--- a/core/line_liff/Cargo.toml
+++ b/core/line_liff/Cargo.toml
@@ -8,12 +8,12 @@ license = "Unlicense"
 edition = "2021"
 
 [dependencies]
-serde = { version = "^1.0", features = ["derive"] }
-serde_json = "^1.0"
-serde_repr = "^0.1"
-url = "^2.5"
-hyper = { version = "^1.3.1", features = ["full"] }
-hyper-util = { version = "0.1.5", features = ["client", "client-legacy", "http1", "http2"] }
-http-body-util = { version = "0.1.2" }
-base64 = "0.22.1"
-futures = "^0.3"
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+serde_repr.workspace = true
+url.workspace = true
+hyper = { workspace = true, features = ["full"] }
+hyper-util = { workspace = true, features = ["client", "client-legacy", "http1", "http2"] }
+http-body-util.workspace = true
+base64.workspace = true
+futures.workspace = true

--- a/core/line_manage_audience/Cargo.toml
+++ b/core/line_manage_audience/Cargo.toml
@@ -8,13 +8,13 @@ license = "Unlicense"
 edition = "2021"
 
 [dependencies]
-serde = { version = "^1.0", features = ["derive"] }
-serde_with = { version = "^3.8", default-features = false, features = ["base64", "std", "macros"] }
-serde_json = "^1.0"
-serde_repr = "^0.1"
-url = "^2.5"
-hyper = { version = "^1.3.1", features = ["full"] }
-hyper-util = { version = "0.1.5", features = ["client", "client-legacy", "http1", "http2"] }
-http-body-util = { version = "0.1.2" }
-base64 = "0.22.1"
-futures = "^0.3"
+serde = { workspace = true, features = ["derive"] }
+serde_with = { workspace = true, default-features = false, features = ["base64", "std", "macros"] }
+serde_json.workspace = true
+serde_repr.workspace = true
+url.workspace = true
+hyper = { workspace = true, features = ["full"] }
+hyper-util = { workspace = true, features = ["client", "client-legacy", "http1", "http2"] }
+http-body-util.workspace = true
+base64.workspace = true
+futures.workspace = true

--- a/core/line_messaging_api/Cargo.toml
+++ b/core/line_messaging_api/Cargo.toml
@@ -8,13 +8,13 @@ license = "Unlicense"
 edition = "2021"
 
 [dependencies]
-serde = { version = "^1.0", features = ["derive"] }
-serde_json = "^1.0"
-serde_repr = "^0.1"
-url = "^2.5"
-uuid = { version = "^1.8", features = ["serde", "v4"] }
-hyper = { version = "^1.3.1", features = ["full"] }
-hyper-util = { version = "0.1.5", features = ["client", "client-legacy", "http1", "http2"] }
-http-body-util = { version = "0.1.2" }
-base64 = "0.22.1"
-futures = "^0.3"
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+serde_repr.workspace = true
+url.workspace = true
+uuid = { workspace = true, features = ["serde", "v4"] }
+hyper = { workspace = true, features = ["full"] }
+hyper-util = { workspace = true, features = ["client", "client-legacy", "http1", "http2"] }
+http-body-util.workspace = true
+base64.workspace = true
+futures.workspace = true

--- a/core/line_module/Cargo.toml
+++ b/core/line_module/Cargo.toml
@@ -8,12 +8,12 @@ license = "Unlicense"
 edition = "2021"
 
 [dependencies]
-serde = { version = "^1.0", features = ["derive"] }
-serde_json = "^1.0"
-serde_repr = "^0.1"
-url = "^2.5"
-hyper = { version = "^1.3.1", features = ["full"] }
-hyper-util = { version = "0.1.5", features = ["client", "client-legacy", "http1", "http2"] }
-http-body-util = { version = "0.1.2" }
-base64 = "0.22.1"
-futures = "^0.3"
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+serde_repr.workspace = true
+url.workspace = true
+hyper = { workspace = true, features = ["full"] }
+hyper-util = { workspace = true, features = ["client", "client-legacy", "http1", "http2"] }
+http-body-util.workspace = true
+base64.workspace = true
+futures.workspace = true

--- a/core/line_module_attach/Cargo.toml
+++ b/core/line_module_attach/Cargo.toml
@@ -8,12 +8,12 @@ license = "Unlicense"
 edition = "2021"
 
 [dependencies]
-serde = { version = "^1.0", features = ["derive"] }
-serde_json = "^1.0"
-serde_repr = "^0.1"
-url = "^2.5"
-hyper = { version = "^1.3.1", features = ["full"] }
-hyper-util = { version = "0.1.5", features = ["client", "client-legacy", "http1", "http2"] }
-http-body-util = { version = "0.1.2" }
-base64 = "0.22.1"
-futures = "^0.3"
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+serde_repr.workspace = true
+url.workspace = true
+hyper = { workspace = true, features = ["full"] }
+hyper-util = { workspace = true, features = ["client", "client-legacy", "http1", "http2"] }
+http-body-util.workspace = true
+base64.workspace = true
+futures.workspace = true

--- a/core/line_shop/Cargo.toml
+++ b/core/line_shop/Cargo.toml
@@ -8,12 +8,12 @@ license = "Unlicense"
 edition = "2021"
 
 [dependencies]
-serde = { version = "^1.0", features = ["derive"] }
-serde_json = "^1.0"
-serde_repr = "^0.1"
-url = "^2.5"
-hyper = { version = "^1.3.1", features = ["full"] }
-hyper-util = { version = "0.1.5", features = ["client", "client-legacy", "http1", "http2"] }
-http-body-util = { version = "0.1.2" }
-base64 = "0.22.1"
-futures = "^0.3"
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+serde_repr.workspace = true
+url.workspace = true
+hyper = { workspace = true, features = ["full"] }
+hyper-util = { workspace = true, features = ["client", "client-legacy", "http1", "http2"] }
+http-body-util.workspace = true
+base64.workspace = true
+futures.workspace = true

--- a/core/line_webhook/Cargo.toml
+++ b/core/line_webhook/Cargo.toml
@@ -8,12 +8,12 @@ license = "Unlicense"
 edition = "2021"
 
 [dependencies]
-serde = { version = "^1.0", features = ["derive"] }
-serde_json = "^1.0"
-serde_repr = "^0.1"
-url = "^2.5"
-hyper = { version = "^1.3.1", features = ["full"] }
-hyper-util = { version = "0.1.5", features = ["client", "client-legacy", "http1", "http2"] }
-http-body-util = { version = "0.1.2" }
-base64 = "0.22.1"
-futures = "^0.3"
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+serde_repr.workspace = true
+url.workspace = true
+hyper = { workspace = true, features = ["full"] }
+hyper-util = { workspace = true, features = ["client", "client-legacy", "http1", "http2"] }
+http-body-util.workspace = true
+base64.workspace = true
+futures.workspace = true

--- a/examples/actix_web_example/Cargo.toml
+++ b/examples/actix_web_example/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 actix-rt = "2.11.0"
 actix-web = "4.13.0"
-dotenv = "0.15.0"
+dotenvy = "0.15.7"
 serde_json = "1.0.149"
 
 [dependencies.line-bot-sdk-rust]

--- a/examples/actix_web_example/src/main.rs
+++ b/examples/actix_web_example/src/main.rs
@@ -1,7 +1,7 @@
 use actix_web::{
     error::ErrorBadRequest, middleware, post, web, App, Error, HttpResponse, HttpServer,
 };
-use dotenv::dotenv;
+use dotenvy::dotenv;
 use line_bot_sdk_rust::{
     client::LINE,
     line_messaging_api::{

--- a/examples/rocket_example/Cargo.toml
+++ b/examples/rocket_example/Cargo.toml
@@ -6,7 +6,7 @@ workspace = "../"
 publish = false
 
 [dependencies]
-dotenv = "0.15.0"
+dotenvy = "0.15.7"
 serde_json = "1.0.149"
 
 [dependencies.rocket]

--- a/examples/rocket_example/src/main.rs
+++ b/examples/rocket_example/src/main.rs
@@ -1,4 +1,4 @@
-use dotenv::dotenv;
+use dotenvy::dotenv;
 use line_bot_sdk_rust::{
     client::LINE,
     line_messaging_api::{
@@ -21,7 +21,7 @@ async fn world(signature: Signature, body: String) -> (Status, &'static str) {
     let access_token: &str =
         &env::var("LINE_CHANNEL_ACCESS_TOKEN").expect("Failed to get LINE_CHANNEL_ACCESS_TOKEN");
 
-    let _line = LINE::new(access_token.to_string());
+    let line = LINE::new(access_token.to_string());
 
     println!("{signature:#?}");
     println!("{body:#?}");
@@ -40,20 +40,19 @@ async fn world(signature: Signature, body: String) -> (Status, &'static str) {
                 if let Event::MessageEvent(message_event) = e {
                     if let MessageContent::TextMessageContent(text_message) = *message_event.message
                     {
-                        let _reply_message_request = ReplyMessageRequest {
+                        let reply_message_request = ReplyMessageRequest {
                             reply_token: message_event.reply_token.unwrap(),
                             messages: vec![Message::Text(TextMessage::new(text_message.text))],
                             notification_disabled: Some(false),
                         };
-                        // TODO: reply_message sample
-                        // let result = line
-                        //     .messaging_api_client
-                        //     .reply_message(reply_message_request)
-                        //     .await;
-                        // match result {
-                        //     Ok(r) => println!("{:#?}", r),
-                        //     Err(e) => println!("{:#?}", e),
-                        // }
+                        let result = line
+                            .messaging_api_client
+                            .reply_message(reply_message_request)
+                            .await;
+                        match result {
+                            Ok(r) => println!("{:#?}", r),
+                            Err(e) => println!("{:#?}", e),
+                        }
                     };
                 };
             }

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -157,6 +157,46 @@ fn fix_generated_dependencies(pkg_dir: &str) {
     }
 }
 
+fn fix_workspace_dependencies(pkg_dir: &str) {
+    let cargo_toml_path = Path::new(pkg_dir).join("Cargo.toml");
+    let replacements: HashMap<&str, &str> = [
+        // Common dependencies -> workspace references
+        (
+            "serde = { version = \"^1.0\", features = [\"derive\"] }",
+            "serde = { workspace = true, features = [\"derive\"] }",
+        ),
+        ("serde_json = \"^1.0\"", "serde_json.workspace = true"),
+        ("serde_repr = \"^0.1\"", "serde_repr.workspace = true"),
+        (
+            "serde_with = { version = \"^3.8\", default-features = false, features = [\"base64\", \"std\", \"macros\"] }",
+            "serde_with = { workspace = true, default-features = false, features = [\"base64\", \"std\", \"macros\"] }",
+        ),
+        ("url = \"^2.5\"", "url.workspace = true"),
+        (
+            "uuid = { version = \"^1.8\", features = [\"serde\", \"v4\"] }",
+            "uuid = { workspace = true, features = [\"serde\", \"v4\"] }",
+        ),
+        (
+            "hyper = { version = \"^1.3.1\", features = [\"full\"] }",
+            "hyper = { workspace = true, features = [\"full\"] }",
+        ),
+        (
+            "hyper-util = { version = \"0.1.5\", features = [\"client\", \"client-legacy\", \"http1\", \"http2\"] }",
+            "hyper-util = { workspace = true, features = [\"client\", \"client-legacy\", \"http1\", \"http2\"] }",
+        ),
+        (
+            "http-body-util = { version = \"0.1.2\" }",
+            "http-body-util.workspace = true",
+        ),
+        ("base64 = \"0.22.1\"", "base64.workspace = true"),
+        ("futures = \"^0.3\"", "futures.workspace = true"),
+    ]
+    .iter()
+    .cloned()
+    .collect();
+    replace_in_file(&cargo_toml_path, replacements);
+}
+
 fn fix_error_type(pkg_dir: &str) {
     let mod_rs_path = Path::new(pkg_dir).join("src/apis/mod.rs");
     if !mod_rs_path.exists() {
@@ -364,6 +404,7 @@ fn main() {
 
         process_directory(&PathBuf::from(pkg_dir), pkg_name);
         fix_generated_dependencies(pkg_dir);
+        fix_workspace_dependencies(pkg_dir);
         fix_error_type(pkg_dir);
         fix_api_client_clone(pkg_dir);
     }


### PR DESCRIPTION
## Summary
- Add `[workspace.dependencies]` to root `Cargo.toml` for centralized version management (serde, hyper, base64, etc.)
- Convert all 9 generated modules and `core/lib` to use `dep.workspace = true` references
- Add `fix_workspace_dependencies()` to generator for automatic workspace ref conversion on `make generate`
- Migrate examples from deprecated `dotenv` crate to `dotenvy`
- Fix rocket example: enable `reply_message` call (was commented out as TODO)

closes #85

## Test plan
- [x] `make generate` succeeds and is idempotent
- [x] `cargo test` passes (25 tests)
- [x] Both examples (`actix_web`, `rocket`) build successfully
- [x] Generated Cargo.toml files use workspace references

🤖 Generated with [Claude Code](https://claude.com/claude-code)