### PR TITLE
Fix Cargo.toml metadata and license inconsistency

### DIFF
--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -7,9 +7,12 @@ rust-version = "1.71.0"
 description = "LINE Messaging API SDK for Rust"
 readme = "../../README.md"
 repository = "https://github.com/nanato12/line-bot-sdk-rust/"
+homepage = "https://github.com/nanato12/line-bot-sdk-rust/"
+documentation = "https://docs.rs/line-bot-sdk-rust"
 license = "Apache-2.0"
 keywords = ["line", "linebot", "line-bot-sdk", "line-messaging-api"]
 categories = ["api-bindings"]
+exclude = ["tests/", "examples/"]
 
 [features]
 default = []

--- a/core/line_channel_access_token/Cargo.toml
+++ b/core/line_channel_access_token/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "line_channel_access_token"
 version = "0.0.2"
-authors = ["OpenAPI Generator team and contributors"]
+authors = ["nanato12 <admin@okj.info>"]
 description = "This document describes Channel Access Token API."
-# Override this license by providing a License Object in the OpenAPI.
-license = "Unlicense"
+license = "Apache-2.0"
+repository = "https://github.com/nanato12/line-bot-sdk-rust/"
 edition = "2021"
 
 [dependencies]

--- a/core/line_insight/Cargo.toml
+++ b/core/line_insight/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "line_insight"
 version = "0.0.2"
-authors = ["OpenAPI Generator team and contributors"]
+authors = ["nanato12 <admin@okj.info>"]
 description = "This document describes LINE Messaging API(Insight)."
-# Override this license by providing a License Object in the OpenAPI.
-license = "Unlicense"
+license = "Apache-2.0"
+repository = "https://github.com/nanato12/line-bot-sdk-rust/"
 edition = "2021"
 
 [dependencies]

--- a/core/line_liff/Cargo.toml
+++ b/core/line_liff/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "line_liff"
 version = "1.1.0"
-authors = ["OpenAPI Generator team and contributors"]
+authors = ["nanato12 <admin@okj.info>"]
 description = "LIFF Server API."
-# Override this license by providing a License Object in the OpenAPI.
-license = "Unlicense"
+license = "Apache-2.0"
+repository = "https://github.com/nanato12/line-bot-sdk-rust/"
 edition = "2021"
 
 [dependencies]

--- a/core/line_manage_audience/Cargo.toml
+++ b/core/line_manage_audience/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "line_manage_audience"
 version = "0.0.2"
-authors = ["OpenAPI Generator team and contributors"]
+authors = ["nanato12 <admin@okj.info>"]
 description = "This document describes LINE Messaging API."
-# Override this license by providing a License Object in the OpenAPI.
-license = "Unlicense"
+license = "Apache-2.0"
+repository = "https://github.com/nanato12/line-bot-sdk-rust/"
 edition = "2021"
 
 [dependencies]

--- a/core/line_messaging_api/Cargo.toml
+++ b/core/line_messaging_api/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "line_messaging_api"
 version = "0.0.4"
-authors = ["OpenAPI Generator team and contributors"]
+authors = ["nanato12 <admin@okj.info>"]
 description = "This document describes LINE Messaging API."
-# Override this license by providing a License Object in the OpenAPI.
-license = "Unlicense"
+license = "Apache-2.0"
+repository = "https://github.com/nanato12/line-bot-sdk-rust/"
 edition = "2021"
 
 [dependencies]

--- a/core/line_module/Cargo.toml
+++ b/core/line_module/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "line_module"
 version = "0.0.2"
-authors = ["OpenAPI Generator team and contributors"]
+authors = ["nanato12 <admin@okj.info>"]
 description = "This document describes LINE Messaging API."
-# Override this license by providing a License Object in the OpenAPI.
-license = "Unlicense"
+license = "Apache-2.0"
+repository = "https://github.com/nanato12/line-bot-sdk-rust/"
 edition = "2021"
 
 [dependencies]

--- a/core/line_module_attach/Cargo.toml
+++ b/core/line_module_attach/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "line_module_attach"
 version = "0.0.2"
-authors = ["OpenAPI Generator team and contributors"]
+authors = ["nanato12 <admin@okj.info>"]
 description = "This document describes LINE Messaging API."
-# Override this license by providing a License Object in the OpenAPI.
-license = "Unlicense"
+license = "Apache-2.0"
+repository = "https://github.com/nanato12/line-bot-sdk-rust/"
 edition = "2021"
 
 [dependencies]

--- a/core/line_shop/Cargo.toml
+++ b/core/line_shop/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "line_shop"
 version = "0.0.1"
-authors = ["OpenAPI Generator team and contributors"]
+authors = ["nanato12 <admin@okj.info>"]
 description = "This document describes LINE Mission Stickers API."
-# Override this license by providing a License Object in the OpenAPI.
-license = "Unlicense"
+license = "Apache-2.0"
+repository = "https://github.com/nanato12/line-bot-sdk-rust/"
 edition = "2021"
 
 [dependencies]

--- a/core/line_webhook/Cargo.toml
+++ b/core/line_webhook/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "line_webhook"
 version = "1.0.2"
-authors = ["OpenAPI Generator team and contributors"]
+authors = ["nanato12 <admin@okj.info>"]
 description = "Webhook event definition of the LINE Messaging API"
-# Override this license by providing a License Object in the OpenAPI.
-license = "Unlicense"
+license = "Apache-2.0"
+repository = "https://github.com/nanato12/line-bot-sdk-rust/"
 edition = "2021"
 
 [dependencies]

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -197,6 +197,24 @@ fn fix_workspace_dependencies(pkg_dir: &str) {
     replace_in_file(&cargo_toml_path, replacements);
 }
 
+fn fix_cargo_metadata(pkg_dir: &str) {
+    let cargo_toml_path = Path::new(pkg_dir).join("Cargo.toml");
+    let replacements: HashMap<&str, &str> = [
+        (
+            "authors = [\"OpenAPI Generator team and contributors\"]",
+            "authors = [\"nanato12 <admin@okj.info>\"]",
+        ),
+        (
+            "# Override this license by providing a License Object in the OpenAPI.\nlicense = \"Unlicense\"",
+            "license = \"Apache-2.0\"\nrepository = \"https://github.com/nanato12/line-bot-sdk-rust/\"",
+        ),
+    ]
+    .iter()
+    .cloned()
+    .collect();
+    replace_in_file(&cargo_toml_path, replacements);
+}
+
 fn fix_workspace_lints(pkg_dir: &str) {
     let cargo_toml_path = Path::new(pkg_dir).join("Cargo.toml");
     let mut contents = read_file(&cargo_toml_path);
@@ -413,6 +431,7 @@ fn main() {
         }
 
         process_directory(&PathBuf::from(pkg_dir), pkg_name);
+        fix_cargo_metadata(pkg_dir);
         fix_generated_dependencies(pkg_dir);
         fix_workspace_dependencies(pkg_dir);
         fix_workspace_lints(pkg_dir);


### PR DESCRIPTION
## Summary
- Change generated crate license from `Unlicense` to `Apache-2.0` (consistent with core/lib)
- Fix authors from `"OpenAPI Generator team and contributors"` to `"nanato12 <admin@okj.info>"`
- Add `repository` field to all 9 generated crates
- Add `homepage`, `documentation`, `exclude` to `core/lib/Cargo.toml`
- Add `fix_cargo_metadata()` to generator for automatic metadata correction on regeneration

close #84

## Test plan
- [ ] `cargo check` passes
- [ ] Verify metadata with `cargo package --list` or `cargo metadata`

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>