### PR TITLE
Add comprehensive test suite

### DIFF
--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -73,5 +73,8 @@ path = "../line_shop"
 version = "1.0.2"
 path = "../line_webhook"
 
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt"] }
+
 [lints]
 workspace = true

--- a/core/lib/tests/actix_extractor.rs
+++ b/core/lib/tests/actix_extractor.rs
@@ -1,0 +1,39 @@
+#![cfg(feature = "actix_support")]
+
+use actix_web::dev::Payload;
+use actix_web::test::TestRequest;
+use actix_web::FromRequest;
+use line_bot_sdk_rust::support::actix::Signature;
+
+#[tokio::test]
+async fn extract_signature_from_valid_header() {
+    let req = TestRequest::default()
+        .insert_header(("x-line-signature", "test_signature_value"))
+        .to_http_request();
+
+    let sig = Signature::from_request(&req, &mut Payload::None)
+        .await
+        .unwrap();
+    assert_eq!(sig.key, "test_signature_value");
+}
+
+#[tokio::test]
+async fn extract_signature_missing_header_returns_error() {
+    let req = TestRequest::default().to_http_request();
+
+    let result = Signature::from_request(&req, &mut Payload::None).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn extract_signature_debug_format() {
+    let req = TestRequest::default()
+        .insert_header(("x-line-signature", "abc123"))
+        .to_http_request();
+
+    let sig = Signature::from_request(&req, &mut Payload::None)
+        .await
+        .unwrap();
+    let debug = format!("{:?}", sig);
+    assert!(debug.contains("abc123"));
+}

--- a/core/lib/tests/client.rs
+++ b/core/lib/tests/client.rs
@@ -1,0 +1,27 @@
+use line_bot_sdk_rust::client::LINE;
+
+#[test]
+fn line_client_new_creates_all_clients() {
+    let line = LINE::new("test_token".to_string());
+
+    // Verify all clients are accessible (they compile and are initialized)
+    let _ = &line.channel_access_token_api_client;
+    let _ = &line.insight_api_client;
+    let _ = &line.liff_api_client;
+    let _ = &line.manage_audience_api_client;
+    let _ = &line.manage_audience_blob_api_client;
+    let _ = &line.messaging_api_client;
+    let _ = &line.messaging_api_blob_client;
+    let _ = &line.module_api_client;
+    let _ = &line.module_attach_api_client;
+    let _ = &line.shop_api_client;
+    let _ = &line.webhook_dummy_api_client;
+}
+
+#[test]
+fn line_client_clone() {
+    let line = LINE::new("test_token".to_string());
+    let cloned = line.clone();
+    // Cloned client should be independent
+    let _ = &cloned.messaging_api_client;
+}

--- a/core/lib/tests/rocket_extractor.rs
+++ b/core/lib/tests/rocket_extractor.rs
@@ -1,0 +1,35 @@
+#![cfg(feature = "rocket_support")]
+
+use line_bot_sdk_rust::support::rocket::Signature;
+use rocket::http::{Header, Status};
+use rocket::local::blocking::Client;
+use rocket::{post, routes};
+
+#[post("/callback")]
+fn callback(signature: Signature) -> String {
+    signature.key
+}
+
+#[test]
+fn extract_signature_from_valid_header() {
+    let rocket = rocket::build().mount("/", routes![callback]);
+    let client = Client::tracked(rocket).unwrap();
+
+    let response = client
+        .post("/callback")
+        .header(Header::new("x-line-signature", "test_signature_value"))
+        .dispatch();
+
+    assert_eq!(response.status(), Status::Ok);
+    assert_eq!(response.into_string().unwrap(), "test_signature_value");
+}
+
+#[test]
+fn extract_signature_missing_header_returns_bad_request() {
+    let rocket = rocket::build().mount("/", routes![callback]);
+    let client = Client::tracked(rocket).unwrap();
+
+    let response = client.post("/callback").dispatch();
+
+    assert_eq!(response.status(), Status::BadRequest);
+}

--- a/core/line_messaging_api/tests/deserialization.rs
+++ b/core/line_messaging_api/tests/deserialization.rs
@@ -1,0 +1,87 @@
+use line_messaging_api::models::{Message, TextMessage};
+
+// ---------------------------------------------------------------------------
+// Message enum
+// ---------------------------------------------------------------------------
+
+#[test]
+fn deserialize_text_message() {
+    let json = r#"{"type":"text","text":"Hello, world!"}"#;
+    let msg: Message = serde_json::from_str(json).unwrap();
+    match &msg {
+        Message::Text(t) => {
+            assert_eq!(t.text, "Hello, world!");
+            assert!(t.quick_reply.is_none());
+            assert!(t.sender.is_none());
+            assert!(t.emojis.is_none());
+        }
+        _ => panic!("expected Text"),
+    }
+    // roundtrip
+    let serialized = serde_json::to_string(&msg).unwrap();
+    let roundtrip: Message = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(msg, roundtrip);
+}
+
+#[test]
+fn serialize_text_message() {
+    let msg = Message::Text(TextMessage::new("Hi!".to_string()));
+    let json = serde_json::to_string(&msg).unwrap();
+    // must contain type discriminator
+    assert!(json.contains(r#""type":"text""#));
+    assert!(json.contains(r#""text":"Hi!""#));
+    // optional fields should be absent
+    assert!(!json.contains("quickReply"));
+    assert!(!json.contains("sender"));
+    assert!(!json.contains("emojis"));
+}
+
+#[test]
+fn deserialize_sticker_message() {
+    let json = r#"{
+        "type": "sticker",
+        "packageId": "446",
+        "stickerId": "1988"
+    }"#;
+    let msg: Message = serde_json::from_str(json).unwrap();
+    match &msg {
+        Message::Sticker(s) => {
+            assert_eq!(s.package_id, "446");
+            assert_eq!(s.sticker_id, "1988");
+        }
+        _ => panic!("expected Sticker"),
+    }
+}
+
+#[test]
+fn deserialize_location_message() {
+    let json = r#"{
+        "type": "location",
+        "title": "my location",
+        "address": "1-6-1 Yotsuya, Shinjuku-ku, Tokyo",
+        "latitude": 35.687574,
+        "longitude": 139.72922
+    }"#;
+    let msg: Message = serde_json::from_str(json).unwrap();
+    match &msg {
+        Message::Location(l) => {
+            assert_eq!(l.title, "my location");
+            assert_eq!(l.address, "1-6-1 Yotsuya, Shinjuku-ku, Tokyo");
+            assert!((l.latitude - 35.687574).abs() < 0.0001);
+            assert!((l.longitude - 139.72922).abs() < 0.0001);
+        }
+        _ => panic!("expected Location"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Roundtrip: construct → serialize → deserialize
+// ---------------------------------------------------------------------------
+
+#[test]
+fn text_message_new_roundtrip() {
+    let original = TextMessage::new("test message".to_string());
+    let json = serde_json::to_value(&original).unwrap();
+    let deserialized: TextMessage = serde_json::from_value(json).unwrap();
+    assert_eq!(original, deserialized);
+}

--- a/core/line_webhook/tests/deserialization.rs
+++ b/core/line_webhook/tests/deserialization.rs
@@ -1,0 +1,464 @@
+use line_webhook::models::{
+    CallbackRequest, DeliveryContext, Event, EventMode, MessageContent, Source,
+};
+
+// ---------------------------------------------------------------------------
+// Source enum
+// ---------------------------------------------------------------------------
+
+#[test]
+fn deserialize_user_source() {
+    let json = r#"{"type":"user","userId":"U1234567890abcdef1234567890abcdef"}"#;
+    let source: Source = serde_json::from_str(json).unwrap();
+    match &source {
+        Source::UserSource(s) => {
+            assert_eq!(
+                s.user_id.as_deref(),
+                Some("U1234567890abcdef1234567890abcdef")
+            );
+        }
+        _ => panic!("expected UserSource"),
+    }
+    // roundtrip
+    let serialized = serde_json::to_string(&source).unwrap();
+    let roundtrip: Source = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(source, roundtrip);
+}
+
+#[test]
+fn deserialize_group_source() {
+    let json = r#"{"type":"group","groupId":"C1234567890abcdef1234567890abcdef","userId":"U1234567890abcdef1234567890abcdef"}"#;
+    let source: Source = serde_json::from_str(json).unwrap();
+    match &source {
+        Source::GroupSource(s) => {
+            assert_eq!(s.group_id, "C1234567890abcdef1234567890abcdef");
+            assert_eq!(
+                s.user_id.as_deref(),
+                Some("U1234567890abcdef1234567890abcdef")
+            );
+        }
+        _ => panic!("expected GroupSource"),
+    }
+}
+
+#[test]
+fn deserialize_group_source_without_user_id() {
+    let json = r#"{"type":"group","groupId":"C1234567890abcdef1234567890abcdef"}"#;
+    let source: Source = serde_json::from_str(json).unwrap();
+    match &source {
+        Source::GroupSource(s) => {
+            assert_eq!(s.group_id, "C1234567890abcdef1234567890abcdef");
+            assert!(s.user_id.is_none());
+        }
+        _ => panic!("expected GroupSource"),
+    }
+}
+
+#[test]
+fn deserialize_room_source() {
+    let json = r#"{"type":"room","roomId":"R1234567890abcdef1234567890abcdef"}"#;
+    let source: Source = serde_json::from_str(json).unwrap();
+    match &source {
+        Source::RoomSource(s) => {
+            assert_eq!(s.room_id, "R1234567890abcdef1234567890abcdef");
+            assert!(s.user_id.is_none());
+        }
+        _ => panic!("expected RoomSource"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MessageContent enum
+// ---------------------------------------------------------------------------
+
+#[test]
+fn deserialize_text_message_content() {
+    let json = r#"{
+        "type": "text",
+        "id": "12345678901234",
+        "text": "Hello, world!",
+        "quoteToken": "q1234567890abcdef"
+    }"#;
+    let msg: MessageContent = serde_json::from_str(json).unwrap();
+    match &msg {
+        MessageContent::TextMessageContent(t) => {
+            assert_eq!(t.id, "12345678901234");
+            assert_eq!(t.text, "Hello, world!");
+            assert_eq!(t.quote_token, "q1234567890abcdef");
+            assert!(t.emojis.is_none());
+            assert!(t.mention.is_none());
+        }
+        _ => panic!("expected TextMessageContent"),
+    }
+    // roundtrip
+    let serialized = serde_json::to_string(&msg).unwrap();
+    let roundtrip: MessageContent = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(msg, roundtrip);
+}
+
+#[test]
+fn deserialize_sticker_message_content() {
+    let json = r#"{
+        "type": "sticker",
+        "id": "12345678901234",
+        "packageId": "1",
+        "stickerId": "1",
+        "stickerResourceType": "STATIC",
+        "quoteToken": "q1234567890abcdef"
+    }"#;
+    let msg: MessageContent = serde_json::from_str(json).unwrap();
+    match &msg {
+        MessageContent::StickerMessageContent(s) => {
+            assert_eq!(s.id, "12345678901234");
+            assert_eq!(s.package_id, "1");
+            assert_eq!(s.sticker_id, "1");
+            assert_eq!(
+                s.sticker_resource_type,
+                line_webhook::models::sticker_message_content::StickerResourceType::Static
+            );
+        }
+        _ => panic!("expected StickerMessageContent"),
+    }
+}
+
+#[test]
+fn deserialize_image_message_content() {
+    let json = r#"{
+        "type": "image",
+        "id": "12345678901234",
+        "contentProvider": {"type": "line"},
+        "quoteToken": "q1234567890abcdef"
+    }"#;
+    let msg: MessageContent = serde_json::from_str(json).unwrap();
+    match &msg {
+        MessageContent::ImageMessageContent(i) => {
+            assert_eq!(i.id, "12345678901234");
+            assert_eq!(
+                i.content_provider.r#type,
+                line_webhook::models::content_provider::Type::Line
+            );
+        }
+        _ => panic!("expected ImageMessageContent"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Event enum
+// ---------------------------------------------------------------------------
+
+#[test]
+fn deserialize_text_message_event() {
+    let json = r#"{
+        "type": "message",
+        "source": {
+            "type": "user",
+            "userId": "U1234567890abcdef1234567890abcdef"
+        },
+        "timestamp": 1704067200000,
+        "mode": "active",
+        "webhookEventId": "01HKTEST1234567890ABCDEFGH",
+        "deliveryContext": {"isRedelivery": false},
+        "replyToken": "nHuyWiB7yP5Zw52FIkcQobQuGDXCTA",
+        "message": {
+            "type": "text",
+            "id": "12345678901234",
+            "text": "Hello!",
+            "quoteToken": "q1234567890abcdef"
+        }
+    }"#;
+    let event: Event = serde_json::from_str(json).unwrap();
+    match &event {
+        Event::MessageEvent(e) => {
+            assert_eq!(e.timestamp, 1704067200000);
+            assert_eq!(e.mode, EventMode::Active);
+            assert_eq!(e.webhook_event_id, "01HKTEST1234567890ABCDEFGH");
+            assert!(!e.delivery_context.is_redelivery);
+            assert_eq!(
+                e.reply_token.as_deref(),
+                Some("nHuyWiB7yP5Zw52FIkcQobQuGDXCTA")
+            );
+            match e.source.as_deref() {
+                Some(Source::UserSource(u)) => {
+                    assert_eq!(
+                        u.user_id.as_deref(),
+                        Some("U1234567890abcdef1234567890abcdef")
+                    );
+                }
+                _ => panic!("expected UserSource"),
+            }
+            match e.message.as_ref() {
+                MessageContent::TextMessageContent(t) => {
+                    assert_eq!(t.text, "Hello!");
+                }
+                _ => panic!("expected TextMessageContent"),
+            }
+        }
+        _ => panic!("expected MessageEvent"),
+    }
+    // roundtrip
+    let serialized = serde_json::to_string(&event).unwrap();
+    let roundtrip: Event = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(event, roundtrip);
+}
+
+#[test]
+fn deserialize_follow_event() {
+    let json = r#"{
+        "type": "follow",
+        "source": {
+            "type": "user",
+            "userId": "U1234567890abcdef1234567890abcdef"
+        },
+        "timestamp": 1704067200000,
+        "mode": "active",
+        "webhookEventId": "01HKTEST1234567890ABCDEFGH",
+        "deliveryContext": {"isRedelivery": false},
+        "replyToken": "nHuyWiB7yP5Zw52FIkcQobQuGDXCTA",
+        "follow": {"isUnblocked": false}
+    }"#;
+    let event: Event = serde_json::from_str(json).unwrap();
+    match &event {
+        Event::FollowEvent(e) => {
+            assert!(!e.follow.is_unblocked);
+            assert_eq!(e.reply_token, "nHuyWiB7yP5Zw52FIkcQobQuGDXCTA");
+        }
+        _ => panic!("expected FollowEvent"),
+    }
+}
+
+#[test]
+fn deserialize_unfollow_event() {
+    let json = r#"{
+        "type": "unfollow",
+        "source": {
+            "type": "user",
+            "userId": "U1234567890abcdef1234567890abcdef"
+        },
+        "timestamp": 1704067200000,
+        "mode": "active",
+        "webhookEventId": "01HKTEST1234567890ABCDEFGH",
+        "deliveryContext": {"isRedelivery": false}
+    }"#;
+    let event: Event = serde_json::from_str(json).unwrap();
+    match &event {
+        Event::UnfollowEvent(e) => {
+            assert_eq!(e.timestamp, 1704067200000);
+        }
+        _ => panic!("expected UnfollowEvent"),
+    }
+}
+
+#[test]
+fn deserialize_postback_event() {
+    let json = r#"{
+        "type": "postback",
+        "source": {
+            "type": "user",
+            "userId": "U1234567890abcdef1234567890abcdef"
+        },
+        "timestamp": 1704067200000,
+        "mode": "active",
+        "webhookEventId": "01HKTEST1234567890ABCDEFGH",
+        "deliveryContext": {"isRedelivery": false},
+        "replyToken": "nHuyWiB7yP5Zw52FIkcQobQuGDXCTA",
+        "postback": {
+            "data": "action=buy&itemid=123"
+        }
+    }"#;
+    let event: Event = serde_json::from_str(json).unwrap();
+    match &event {
+        Event::PostbackEvent(e) => {
+            assert_eq!(e.postback.data, "action=buy&itemid=123");
+            assert!(e.postback.params.is_none());
+        }
+        _ => panic!("expected PostbackEvent"),
+    }
+}
+
+#[test]
+fn deserialize_postback_event_with_params() {
+    let json = r#"{
+        "type": "postback",
+        "source": {
+            "type": "user",
+            "userId": "U1234567890abcdef1234567890abcdef"
+        },
+        "timestamp": 1704067200000,
+        "mode": "active",
+        "webhookEventId": "01HKTEST1234567890ABCDEFGH",
+        "deliveryContext": {"isRedelivery": false},
+        "postback": {
+            "data": "action=buy",
+            "params": {"date": "2024-01-01"}
+        }
+    }"#;
+    let event: Event = serde_json::from_str(json).unwrap();
+    match &event {
+        Event::PostbackEvent(e) => {
+            let params = e.postback.params.as_ref().unwrap();
+            assert_eq!(params.get("date").unwrap(), "2024-01-01");
+        }
+        _ => panic!("expected PostbackEvent"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CallbackRequest (full webhook payload)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn deserialize_callback_request_with_text_message() {
+    let json = r#"{
+        "destination": "U1234567890abcdef1234567890abcdef",
+        "events": [
+            {
+                "type": "message",
+                "source": {
+                    "type": "user",
+                    "userId": "Udeadbeefdeadbeefdeadbeefdeadbeef"
+                },
+                "timestamp": 1704067200000,
+                "mode": "active",
+                "webhookEventId": "01HKTEST1234567890ABCDEFGH",
+                "deliveryContext": {"isRedelivery": false},
+                "replyToken": "replytoken123",
+                "message": {
+                    "type": "text",
+                    "id": "99999999999999",
+                    "text": "Hello from LINE!",
+                    "quoteToken": "qt123"
+                }
+            }
+        ]
+    }"#;
+    let req: CallbackRequest = serde_json::from_str(json).unwrap();
+    assert_eq!(req.destination, "U1234567890abcdef1234567890abcdef");
+    assert_eq!(req.events.len(), 1);
+    match &req.events[0] {
+        Event::MessageEvent(e) => {
+            match e.message.as_ref() {
+                MessageContent::TextMessageContent(t) => {
+                    assert_eq!(t.text, "Hello from LINE!");
+                }
+                _ => panic!("expected TextMessageContent"),
+            }
+        }
+        _ => panic!("expected MessageEvent"),
+    }
+    // roundtrip
+    let serialized = serde_json::to_string(&req).unwrap();
+    let roundtrip: CallbackRequest = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(req, roundtrip);
+}
+
+#[test]
+fn deserialize_callback_request_empty_events() {
+    let json = r#"{"destination":"U1234567890abcdef1234567890abcdef","events":[]}"#;
+    let req: CallbackRequest = serde_json::from_str(json).unwrap();
+    assert_eq!(req.destination, "U1234567890abcdef1234567890abcdef");
+    assert!(req.events.is_empty());
+}
+
+#[test]
+fn deserialize_callback_request_multiple_events() {
+    let json = r#"{
+        "destination": "U1234567890abcdef1234567890abcdef",
+        "events": [
+            {
+                "type": "follow",
+                "source": {"type": "user", "userId": "Uaaa"},
+                "timestamp": 1704067200000,
+                "mode": "active",
+                "webhookEventId": "01HKFOLLOW",
+                "deliveryContext": {"isRedelivery": false},
+                "replyToken": "rt1",
+                "follow": {"isUnblocked": false}
+            },
+            {
+                "type": "message",
+                "source": {"type": "group", "groupId": "Cgroup123"},
+                "timestamp": 1704067201000,
+                "mode": "active",
+                "webhookEventId": "01HKMESSAGE",
+                "deliveryContext": {"isRedelivery": true},
+                "replyToken": "rt2",
+                "message": {
+                    "type": "text",
+                    "id": "111",
+                    "text": "Hi",
+                    "quoteToken": "qt"
+                }
+            }
+        ]
+    }"#;
+    let req: CallbackRequest = serde_json::from_str(json).unwrap();
+    assert_eq!(req.events.len(), 2);
+    assert!(matches!(&req.events[0], Event::FollowEvent(_)));
+    assert!(matches!(&req.events[1], Event::MessageEvent(_)));
+    match &req.events[1] {
+        Event::MessageEvent(e) => {
+            assert!(e.delivery_context.is_redelivery);
+            match e.source.as_deref() {
+                Some(Source::GroupSource(g)) => {
+                    assert_eq!(g.group_id, "Cgroup123");
+                }
+                _ => panic!("expected GroupSource"),
+            }
+        }
+        _ => unreachable!(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// EventMode / DeliveryContext
+// ---------------------------------------------------------------------------
+
+#[test]
+fn event_mode_roundtrip() {
+    let active: EventMode = serde_json::from_str(r#""active""#).unwrap();
+    assert_eq!(active, EventMode::Active);
+    let standby: EventMode = serde_json::from_str(r#""standby""#).unwrap();
+    assert_eq!(standby, EventMode::Standby);
+
+    assert_eq!(serde_json::to_string(&EventMode::Active).unwrap(), r#""active""#);
+    assert_eq!(serde_json::to_string(&EventMode::Standby).unwrap(), r#""standby""#);
+}
+
+#[test]
+fn delivery_context_roundtrip() {
+    let json = r#"{"isRedelivery":true}"#;
+    let ctx: DeliveryContext = serde_json::from_str(json).unwrap();
+    assert!(ctx.is_redelivery);
+    let serialized = serde_json::to_string(&ctx).unwrap();
+    assert_eq!(serialized, json);
+}
+
+// ---------------------------------------------------------------------------
+// Standby mode event
+// ---------------------------------------------------------------------------
+
+#[test]
+fn deserialize_standby_mode_event() {
+    let json = r#"{
+        "type": "message",
+        "timestamp": 1704067200000,
+        "mode": "standby",
+        "webhookEventId": "01HKSTANDBY",
+        "deliveryContext": {"isRedelivery": false},
+        "message": {
+            "type": "text",
+            "id": "111",
+            "text": "standby msg",
+            "quoteToken": "qt"
+        }
+    }"#;
+    let event: Event = serde_json::from_str(json).unwrap();
+    match &event {
+        Event::MessageEvent(e) => {
+            assert_eq!(e.mode, EventMode::Standby);
+            assert!(e.source.is_none());
+            assert!(e.reply_token.is_none());
+        }
+        _ => panic!("expected MessageEvent"),
+    }
+}

--- a/core/line_webhook/tests/deserialization.rs
+++ b/core/line_webhook/tests/deserialization.rs
@@ -335,14 +335,12 @@ fn deserialize_callback_request_with_text_message() {
     assert_eq!(req.destination, "U1234567890abcdef1234567890abcdef");
     assert_eq!(req.events.len(), 1);
     match &req.events[0] {
-        Event::MessageEvent(e) => {
-            match e.message.as_ref() {
-                MessageContent::TextMessageContent(t) => {
-                    assert_eq!(t.text, "Hello from LINE!");
-                }
-                _ => panic!("expected TextMessageContent"),
+        Event::MessageEvent(e) => match e.message.as_ref() {
+            MessageContent::TextMessageContent(t) => {
+                assert_eq!(t.text, "Hello from LINE!");
             }
-        }
+            _ => panic!("expected TextMessageContent"),
+        },
         _ => panic!("expected MessageEvent"),
     }
     // roundtrip
@@ -420,8 +418,14 @@ fn event_mode_roundtrip() {
     let standby: EventMode = serde_json::from_str(r#""standby""#).unwrap();
     assert_eq!(standby, EventMode::Standby);
 
-    assert_eq!(serde_json::to_string(&EventMode::Active).unwrap(), r#""active""#);
-    assert_eq!(serde_json::to_string(&EventMode::Standby).unwrap(), r#""standby""#);
+    assert_eq!(
+        serde_json::to_string(&EventMode::Active).unwrap(),
+        r#""active""#
+    );
+    assert_eq!(
+        serde_json::to_string(&EventMode::Standby).unwrap(),
+        r#""standby""#
+    );
 }
 
 #[test]

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -409,12 +409,23 @@ fn main() {
         let pkg_name = &format!("{PKG_NAME_PREFIX}_{}", service.replace("-", "_"));
         let pkg_dir = &format!("{OUTPUT_DIR}/{pkg_name}");
 
-        // Initialize package directory
+        // Initialize package directory (preserve hand-written tests/)
+        let tests_dir = Path::new(pkg_dir).join("tests");
+        let tests_backup = Path::new(pkg_dir).with_file_name(format!("{pkg_name}_tests_backup"));
+        let has_tests = tests_dir.exists();
+        if has_tests {
+            fs::rename(&tests_dir, &tests_backup)
+                .unwrap_or_else(|e| panic!("Failed to backup tests/: {e}"));
+        }
         if Path::new(pkg_dir).exists() {
             fs::remove_dir_all(pkg_dir)
                 .unwrap_or_else(|e| panic!("Failed to remove {pkg_dir}: {e}"));
         }
         fs::create_dir_all(pkg_dir).unwrap_or_else(|e| panic!("Failed to create {pkg_dir}: {e}"));
+        if has_tests {
+            fs::rename(&tests_backup, &tests_dir)
+                .unwrap_or_else(|e| panic!("Failed to restore tests/: {e}"));
+        }
 
         // Place .openapi-generator-ignore in the package directory
         fs::copy(

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -338,6 +338,10 @@ fn process_directory(dir_path: &PathBuf, pkg_name: &str) {
     {
         let path = entry.path();
         if path.is_dir() {
+            // Skip hand-written tests directory
+            if path.file_name().map_or(false, |n| n == "tests") {
+                continue;
+            }
             process_directory(&path, pkg_name);
             continue;
         }

--- a/tools/.openapi-generator-ignore
+++ b/tools/.openapi-generator-ignore
@@ -4,3 +4,4 @@
 git_push.sh
 docs/*
 README.md
+tests/*


### PR DESCRIPTION
## Summary
- Webhook model deserialization tests (18 tests): Event, Source, MessageContent enum variants, CallbackRequest, roundtrip
- Messaging API model deserialization tests (5 tests): Message enum, TextMessage, StickerMessage, LocationMessage
- LINE client tests (2 tests): construction, clone
- actix-web Signature extractor tests (3 tests): valid/missing header, debug format
- Rocket Signature extractor tests (2 tests): valid/missing header
- `.openapi-generator-ignore` に `tests/*` を追加し、再生成時にテストが消えないよう保護（Go SDKの `tests/handwritten/` パターンに倣う）
- async test用に `tokio` dev-dependencyを追加

## Test plan
- [x] `cargo test --workspace` 全テストパス (30 hand-written + 18 doc tests + 1 signature doc test)
- [x] `cargo test -p line-bot-sdk-rust --features actix_support --test actix_extractor` パス
- [x] `cargo test -p line-bot-sdk-rust --features rocket_support --test rocket_extractor` パス

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)