### PR TITLE
Add axum support and request timeout configuration

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Clippy with actix_support
         run: cargo clippy --all-targets --features actix_support -- -D warnings
 
+      - name: Clippy with axum_support
+        run: cargo clippy --all-targets --features axum_support -- -D warnings
+
       - name: Clippy for examples
         run: cargo clippy --all-targets -- -D warnings
         working-directory: examples
@@ -92,6 +95,9 @@ jobs:
 
       - name: Build with actix_support
         run: cargo build --verbose --features actix_support
+
+      - name: Build with axum_support
+        run: cargo build --verbose --features axum_support
 
       - name: Build for examples
         run: cargo build --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ base64 = "0.22.1"
 futures = "^0.3"
 hmac = "0.12.1"
 sha2 = "0.10.8"
+tokio = "^1"
 
 # Lints for generated code — these patterns come from OpenAPI Generator
 # and will be addressed by improving the generator templates.

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -3,7 +3,7 @@ name = "line-bot-sdk-rust"
 version = "1.0.2"
 authors = ["nanato12 <admin@okj.info>"]
 edition = "2021"
-rust-version = "1.71.0"
+rust-version = "1.75.0"
 description = "LINE Messaging API SDK for Rust"
 readme = "../../README.md"
 repository = "https://github.com/nanato12/line-bot-sdk-rust/"
@@ -18,6 +18,7 @@ exclude = ["tests/", "examples/"]
 default = []
 rocket_support = ["rocket"]
 actix_support = ["actix-web"]
+axum_support = ["axum"]
 
 [dependencies]
 base64.workspace = true
@@ -34,6 +35,11 @@ default-features = false
 
 [dependencies.actix-web]
 version = "4.13.0"
+optional = true
+default-features = false
+
+[dependencies.axum]
+version = "0.8"
 optional = true
 default-features = false
 

--- a/core/lib/src/client/mod.rs
+++ b/core/lib/src/client/mod.rs
@@ -19,6 +19,7 @@
 //! Provides the [`LINE`] struct, which bundles all LINE API clients into a single entry point.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use hyper_rustls::HttpsConnector;
 use hyper_rustls::HttpsConnectorBuilder;
@@ -97,28 +98,91 @@ impl LINE {
     /// All API-specific clients are initialized with the same token and share a single
     /// HTTPS connection via `hyper` + `hyper-rustls`.
     pub fn new(token: String) -> LINE {
+        LINEBuilder {
+            token,
+            timeout: None,
+        }
+        .build()
+    }
+
+    /// Returns a [`LINEBuilder`] for constructing a `LINE` client with custom settings.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use std::time::Duration;
+    /// use line_bot_sdk_rust::client::LINE;
+    ///
+    /// let line = LINE::builder("YOUR_CHANNEL_ACCESS_TOKEN".to_string())
+    ///     .timeout(Duration::from_secs(30))
+    ///     .build();
+    /// ```
+    pub fn builder(token: String) -> LINEBuilder {
+        LINEBuilder {
+            token,
+            timeout: None,
+        }
+    }
+
+    fn create_hyper_client() -> Client<HttpsClient, String> {
+        let https = HttpsConnectorBuilder::new()
+            .with_native_roots()
+            .expect("no native root certs found")
+            .https_only()
+            .enable_http1()
+            .build();
+        Client::builder(TokioExecutor::new()).build(https)
+    }
+}
+
+/// Builder for configuring a [`LINE`] client.
+///
+/// Obtained via [`LINE::builder`].
+pub struct LINEBuilder {
+    token: String,
+    timeout: Option<Duration>,
+}
+
+impl LINEBuilder {
+    /// Sets the request timeout for all API calls.
+    ///
+    /// When set, each HTTP request will fail with a timeout error if it does not
+    /// complete within the specified duration. By default there is no timeout.
+    pub fn timeout(mut self, duration: Duration) -> Self {
+        self.timeout = Some(duration);
+        self
+    }
+
+    /// Builds the [`LINE`] client with the configured settings.
+    pub fn build(self) -> LINE {
         let client = LINE::create_hyper_client();
+        let timeout = self.timeout;
+        let token = self.token;
 
         // channel_access_token_api
         let mut channel_access_token_api_conf =
             ChannelAccessTokenApiConfiguration::with_client(client.clone());
         channel_access_token_api_conf.oauth_access_token = Some(token.to_owned());
+        channel_access_token_api_conf.timeout = timeout;
         let channel_access_token_api_client =
             ChannelAccessTokenApiClient::new(Arc::new(channel_access_token_api_conf));
 
         // insight
         let mut insight_conf = InsightConfiguration::with_client(client.clone());
         insight_conf.oauth_access_token = Some(token.to_owned());
+        insight_conf.timeout = timeout;
         let insight_api_client = InsightApiClient::new(Arc::new(insight_conf));
 
         // liff
         let mut liff_conf = LiffConfiguration::with_client(client.clone());
         liff_conf.oauth_access_token = Some(token.to_owned());
+        liff_conf.timeout = timeout;
         let liff_api_client = LiffApiClient::new(Arc::new(liff_conf));
 
         // manage_audience
         let mut manage_audience_conf = ManageAudienceConfiguration::with_client(client.clone());
         manage_audience_conf.oauth_access_token = Some(token.to_owned());
+        manage_audience_conf.timeout = timeout;
         let manage_audience_api_client =
             ManageAudienceApiClient::new(Arc::new(manage_audience_conf));
 
@@ -126,38 +190,45 @@ impl LINE {
         let mut manage_audience_blob_conf =
             ManageAudienceConfiguration::with_client(client.clone());
         manage_audience_blob_conf.oauth_access_token = Some(token.to_owned());
+        manage_audience_blob_conf.timeout = timeout;
         let manage_audience_blob_api_client =
             ManageAudienceBlobApiClient::new(Arc::new(manage_audience_blob_conf));
 
         // messaging_api
         let mut messaging_api_conf = MessagingApiConfiguration::with_client(client.clone());
         messaging_api_conf.oauth_access_token = Some(token.to_owned());
+        messaging_api_conf.timeout = timeout;
         let messaging_api_client = MessagingApiApiClient::new(Arc::new(messaging_api_conf));
 
         // messaging_api_blob
         let mut messaging_api_blob_conf = MessagingApiConfiguration::with_client(client.clone());
         messaging_api_blob_conf.oauth_access_token = Some(token.to_owned());
+        messaging_api_blob_conf.timeout = timeout;
         let messaging_api_blob_client =
             MessagingApiBlobApiClient::new(Arc::new(messaging_api_blob_conf));
 
         // module
         let mut module_conf = LineModuleConfiguration::with_client(client.clone());
         module_conf.oauth_access_token = Some(token.to_owned());
+        module_conf.timeout = timeout;
         let module_api_client = LineModuleApiClient::new(Arc::new(module_conf));
 
         // module_attach
         let mut module_attach_conf = LineModuleAttachConfiguration::with_client(client.clone());
         module_attach_conf.oauth_access_token = Some(token.to_owned());
+        module_attach_conf.timeout = timeout;
         let module_attach_api_client = LineModuleAttachApiClient::new(Arc::new(module_attach_conf));
 
         // shop
         let mut shop_conf = ShopConfiguration::with_client(client.clone());
         shop_conf.oauth_access_token = Some(token.to_owned());
+        shop_conf.timeout = timeout;
         let shop_api_client = ShopApiClient::new(Arc::new(shop_conf));
 
         // webhook
         let mut webhook_conf = WebhookConfiguration::with_client(client.clone());
         webhook_conf.oauth_access_token = Some(token.to_owned());
+        webhook_conf.timeout = timeout;
         let webhook_dummy_api_client = WebhookDummyApiClient::new(Arc::new(webhook_conf));
 
         LINE {
@@ -173,15 +244,5 @@ impl LINE {
             shop_api_client,
             webhook_dummy_api_client,
         }
-    }
-
-    fn create_hyper_client() -> Client<HttpsClient, String> {
-        let https = HttpsConnectorBuilder::new()
-            .with_native_roots()
-            .expect("no native root certs found")
-            .https_only()
-            .enable_http1()
-            .build();
-        Client::builder(TokioExecutor::new()).build(https)
     }
 }

--- a/core/lib/src/lib.rs
+++ b/core/lib/src/lib.rs
@@ -35,6 +35,7 @@
 //! |---------|-------------|
 //! | `rocket_support` | Enables [`support::rocket::Signature`] extractor for the Rocket framework |
 //! | `actix_support` | Enables [`support::actix::Signature`] extractor for the actix-web framework |
+//! | `axum_support` | Enables [`support::axum::Signature`] extractor for the axum framework |
 //!
 //! ## Modules
 //!

--- a/core/lib/src/support/axum.rs
+++ b/core/lib/src/support/axum.rs
@@ -1,0 +1,80 @@
+/*
+* Copyright 2023 nanato12
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+//! axum framework integration for LINE webhook signature extraction.
+
+use axum::extract::FromRequestParts;
+use axum::http::request::Parts;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+
+/// Extracts the `x-line-signature` header value from an axum request.
+///
+/// Implements [`FromRequestParts`] so it can be used as an extractor.
+///
+/// # Example
+///
+/// ```ignore
+/// use axum::{routing::post, Router};
+/// use line_bot_sdk_rust::support::axum::Signature;
+///
+/// async fn callback(signature: Signature, body: String) -> &'static str {
+///     // Use signature.key for validation
+///     "ok"
+/// }
+///
+/// let app = Router::new().route("/callback", post(callback));
+/// ```
+#[derive(Debug)]
+pub struct Signature {
+    /// The value of the `x-line-signature` header.
+    pub key: String,
+}
+
+/// Rejection type returned when the `x-line-signature` header is missing or invalid.
+#[derive(Debug)]
+pub struct SignatureRejection {
+    message: &'static str,
+}
+
+impl IntoResponse for SignatureRejection {
+    fn into_response(self) -> Response {
+        (StatusCode::BAD_REQUEST, self.message).into_response()
+    }
+}
+
+impl<S> FromRequestParts<S> for Signature
+where
+    S: Send + Sync,
+{
+    type Rejection = SignatureRejection;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        match parts.headers.get("x-line-signature") {
+            Some(value) => match value.to_str() {
+                Ok(key) => Ok(Signature {
+                    key: key.to_string(),
+                }),
+                Err(_) => Err(SignatureRejection {
+                    message: "x-line-signature contains invalid characters",
+                }),
+            },
+            None => Err(SignatureRejection {
+                message: "x-line-signature is missing",
+            }),
+        }
+    }
+}

--- a/core/lib/src/support/mod.rs
+++ b/core/lib/src/support/mod.rs
@@ -21,9 +21,13 @@
 //!
 //! - `rocket_support` — [`rocket::Signature`]
 //! - `actix_support` — [`actix::Signature`]
+//! - `axum_support` — [`axum::Signature`]
 
 #[cfg(feature = "rocket_support")]
 pub mod rocket;
 
 #[cfg(feature = "actix_support")]
 pub mod actix;
+
+#[cfg(feature = "axum_support")]
+pub mod axum;

--- a/core/lib/tests/axum_extractor.rs
+++ b/core/lib/tests/axum_extractor.rs
@@ -1,0 +1,39 @@
+#![cfg(feature = "axum_support")]
+
+use axum::extract::FromRequestParts;
+use axum::http::Request;
+use line_bot_sdk_rust::support::axum::Signature;
+
+#[tokio::test]
+async fn extract_signature_from_valid_header() {
+    let (mut parts, _body) = Request::builder()
+        .header("x-line-signature", "test_signature_value")
+        .body(())
+        .unwrap()
+        .into_parts();
+    let sig = Signature::from_request_parts(&mut parts, &())
+        .await
+        .unwrap();
+    assert_eq!(sig.key, "test_signature_value");
+}
+
+#[tokio::test]
+async fn extract_signature_missing_header_returns_error() {
+    let (mut parts, _body) = Request::builder().body(()).unwrap().into_parts();
+    let result = Signature::from_request_parts(&mut parts, &()).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn extract_signature_debug_format() {
+    let (mut parts, _body) = Request::builder()
+        .header("x-line-signature", "abc123")
+        .body(())
+        .unwrap()
+        .into_parts();
+    let sig = Signature::from_request_parts(&mut parts, &())
+        .await
+        .unwrap();
+    let debug = format!("{:?}", sig);
+    assert!(debug.contains("abc123"));
+}

--- a/core/lib/tests/client.rs
+++ b/core/lib/tests/client.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use line_bot_sdk_rust::client::LINE;
 
 #[test]
@@ -24,4 +26,18 @@ fn line_client_clone() {
     let cloned = line.clone();
     // Cloned client should be independent
     let _ = &cloned.messaging_api_client;
+}
+
+#[test]
+fn line_client_builder_default() {
+    let line = LINE::builder("test_token".to_string()).build();
+    let _ = &line.messaging_api_client;
+}
+
+#[test]
+fn line_client_builder_with_timeout() {
+    let line = LINE::builder("test_token".to_string())
+        .timeout(Duration::from_secs(30))
+        .build();
+    let _ = &line.messaging_api_client;
 }

--- a/core/line_channel_access_token/Cargo.toml
+++ b/core/line_channel_access_token/Cargo.toml
@@ -17,6 +17,7 @@ hyper-util = { workspace = true, features = ["client", "client-legacy", "http1",
 http-body-util.workspace = true
 base64.workspace = true
 futures.workspace = true
+tokio = { workspace = true, features = ["time"] }
 
 [lints]
 workspace = true

--- a/core/line_channel_access_token/src/apis/configuration.rs
+++ b/core/line_channel_access_token/src/apis/configuration.rs
@@ -29,6 +29,7 @@ use hyper_util::client::legacy::connect::Connect;
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::client::legacy::Client;
 use hyper_util::rt::TokioExecutor;
+use std::time::Duration;
 
 pub struct Configuration<C: Connect = HttpConnector>
 where
@@ -40,6 +41,7 @@ where
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,
     pub api_key: Option<ApiKey>,
+    pub timeout: Option<Duration>,
     // TODO: take an oauth2 token source, similar to the go one
 }
 
@@ -99,6 +101,7 @@ where
             basic_auth: None,
             oauth_access_token: None,
             api_key: None,
+            timeout: None,
         }
     }
 }

--- a/core/line_channel_access_token/src/apis/mod.rs
+++ b/core/line_channel_access_token/src/apis/mod.rs
@@ -30,6 +30,7 @@ pub enum Error {
     Hyper(hyper::Error),
     HyperClient(hyper_util::client::legacy::Error),
     Serde(serde_json::Error),
+    Timeout,
     UriError(http::uri::InvalidUri),
 }
 
@@ -65,6 +66,7 @@ impl fmt::Display for Error {
             Error::Hyper(e) => write!(f, "hyper error: {}", e),
             Error::HyperClient(e) => write!(f, "hyper client error: {}", e),
             Error::Serde(e) => write!(f, "serde error: {}", e),
+            Error::Timeout => write!(f, "request timed out"),
             Error::UriError(e) => write!(f, "URI error: {}", e),
         }
     }

--- a/core/line_channel_access_token/src/apis/request.rs
+++ b/core/line_channel_access_token/src/apis/request.rs
@@ -240,41 +240,45 @@ impl Request {
         };
 
         let no_return_type = self.no_return_type;
-        Box::pin(
-            conf.client
-                .request(request)
-                .map_err(|e| Error::from(e))
-                .and_then(move |response| {
-                    let status = response.status();
-                    if !status.is_success() {
-                        futures::future::err::<U, Error>(Error::from((
-                            status,
-                            response.into_body(),
-                        )))
+        let timeout_duration = conf.timeout;
+        let fut = conf
+            .client
+            .request(request)
+            .map_err(|e| Error::from(e))
+            .and_then(move |response| {
+                let status = response.status();
+                if !status.is_success() {
+                    futures::future::err::<U, Error>(Error::from((status, response.into_body())))
                         .boxed()
-                    } else if no_return_type {
-                        // This is a hack; if there's no_ret_type, U is (), but serde_json gives an
-                        // error when deserializing "" into (), so deserialize 'null' into it
-                        // instead.
-                        // An alternate option would be to require U: Default, and then return
-                        // U::default() here instead since () implements that, but then we'd
-                        // need to impl default for all models.
-                        futures::future::ok::<U, Error>(
-                            serde_json::from_str("null").expect("serde null value"),
-                        )
-                        .boxed()
-                    } else {
-                        let collect = response.into_body().collect().map_err(Error::from);
-                        collect
-                            .map(|collected| {
-                                collected.and_then(|collected| {
-                                    serde_json::from_slice(&collected.to_bytes())
-                                        .map_err(Error::from)
-                                })
+                } else if no_return_type {
+                    // This is a hack; if there's no_ret_type, U is (), but serde_json gives an
+                    // error when deserializing "" into (), so deserialize 'null' into it
+                    // instead.
+                    // An alternate option would be to require U: Default, and then return
+                    // U::default() here instead since () implements that, but then we'd
+                    // need to impl default for all models.
+                    futures::future::ok::<U, Error>(
+                        serde_json::from_str("null").expect("serde null value"),
+                    )
+                    .boxed()
+                } else {
+                    let collect = response.into_body().collect().map_err(Error::from);
+                    collect
+                        .map(|collected| {
+                            collected.and_then(|collected| {
+                                serde_json::from_slice(&collected.to_bytes()).map_err(Error::from)
                             })
-                            .boxed()
-                    }
-                }),
-        )
+                        })
+                        .boxed()
+                }
+            });
+        match timeout_duration {
+            Some(d) => Box::pin(async move {
+                tokio::time::timeout(d, fut)
+                    .await
+                    .unwrap_or(Err(Error::Timeout))
+            }),
+            None => Box::pin(fut),
+        }
     }
 }

--- a/core/line_insight/Cargo.toml
+++ b/core/line_insight/Cargo.toml
@@ -18,6 +18,7 @@ hyper-util = { workspace = true, features = ["client", "client-legacy", "http1",
 http-body-util.workspace = true
 base64.workspace = true
 futures.workspace = true
+tokio = { workspace = true, features = ["time"] }
 
 [lints]
 workspace = true

--- a/core/line_insight/src/apis/configuration.rs
+++ b/core/line_insight/src/apis/configuration.rs
@@ -29,6 +29,7 @@ use hyper_util::client::legacy::connect::Connect;
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::client::legacy::Client;
 use hyper_util::rt::TokioExecutor;
+use std::time::Duration;
 
 pub struct Configuration<C: Connect = HttpConnector>
 where
@@ -40,6 +41,7 @@ where
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,
     pub api_key: Option<ApiKey>,
+    pub timeout: Option<Duration>,
     // TODO: take an oauth2 token source, similar to the go one
 }
 
@@ -99,6 +101,7 @@ where
             basic_auth: None,
             oauth_access_token: None,
             api_key: None,
+            timeout: None,
         }
     }
 }

--- a/core/line_insight/src/apis/mod.rs
+++ b/core/line_insight/src/apis/mod.rs
@@ -30,6 +30,7 @@ pub enum Error {
     Hyper(hyper::Error),
     HyperClient(hyper_util::client::legacy::Error),
     Serde(serde_json::Error),
+    Timeout,
     UriError(http::uri::InvalidUri),
 }
 
@@ -65,6 +66,7 @@ impl fmt::Display for Error {
             Error::Hyper(e) => write!(f, "hyper error: {}", e),
             Error::HyperClient(e) => write!(f, "hyper client error: {}", e),
             Error::Serde(e) => write!(f, "serde error: {}", e),
+            Error::Timeout => write!(f, "request timed out"),
             Error::UriError(e) => write!(f, "URI error: {}", e),
         }
     }

--- a/core/line_insight/src/apis/request.rs
+++ b/core/line_insight/src/apis/request.rs
@@ -240,41 +240,45 @@ impl Request {
         };
 
         let no_return_type = self.no_return_type;
-        Box::pin(
-            conf.client
-                .request(request)
-                .map_err(|e| Error::from(e))
-                .and_then(move |response| {
-                    let status = response.status();
-                    if !status.is_success() {
-                        futures::future::err::<U, Error>(Error::from((
-                            status,
-                            response.into_body(),
-                        )))
+        let timeout_duration = conf.timeout;
+        let fut = conf
+            .client
+            .request(request)
+            .map_err(|e| Error::from(e))
+            .and_then(move |response| {
+                let status = response.status();
+                if !status.is_success() {
+                    futures::future::err::<U, Error>(Error::from((status, response.into_body())))
                         .boxed()
-                    } else if no_return_type {
-                        // This is a hack; if there's no_ret_type, U is (), but serde_json gives an
-                        // error when deserializing "" into (), so deserialize 'null' into it
-                        // instead.
-                        // An alternate option would be to require U: Default, and then return
-                        // U::default() here instead since () implements that, but then we'd
-                        // need to impl default for all models.
-                        futures::future::ok::<U, Error>(
-                            serde_json::from_str("null").expect("serde null value"),
-                        )
-                        .boxed()
-                    } else {
-                        let collect = response.into_body().collect().map_err(Error::from);
-                        collect
-                            .map(|collected| {
-                                collected.and_then(|collected| {
-                                    serde_json::from_slice(&collected.to_bytes())
-                                        .map_err(Error::from)
-                                })
+                } else if no_return_type {
+                    // This is a hack; if there's no_ret_type, U is (), but serde_json gives an
+                    // error when deserializing "" into (), so deserialize 'null' into it
+                    // instead.
+                    // An alternate option would be to require U: Default, and then return
+                    // U::default() here instead since () implements that, but then we'd
+                    // need to impl default for all models.
+                    futures::future::ok::<U, Error>(
+                        serde_json::from_str("null").expect("serde null value"),
+                    )
+                    .boxed()
+                } else {
+                    let collect = response.into_body().collect().map_err(Error::from);
+                    collect
+                        .map(|collected| {
+                            collected.and_then(|collected| {
+                                serde_json::from_slice(&collected.to_bytes()).map_err(Error::from)
                             })
-                            .boxed()
-                    }
-                }),
-        )
+                        })
+                        .boxed()
+                }
+            });
+        match timeout_duration {
+            Some(d) => Box::pin(async move {
+                tokio::time::timeout(d, fut)
+                    .await
+                    .unwrap_or(Err(Error::Timeout))
+            }),
+            None => Box::pin(fut),
+        }
     }
 }

--- a/core/line_liff/Cargo.toml
+++ b/core/line_liff/Cargo.toml
@@ -17,6 +17,7 @@ hyper-util = { workspace = true, features = ["client", "client-legacy", "http1",
 http-body-util.workspace = true
 base64.workspace = true
 futures.workspace = true
+tokio = { workspace = true, features = ["time"] }
 
 [lints]
 workspace = true

--- a/core/line_liff/src/apis/configuration.rs
+++ b/core/line_liff/src/apis/configuration.rs
@@ -29,6 +29,7 @@ use hyper_util::client::legacy::connect::Connect;
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::client::legacy::Client;
 use hyper_util::rt::TokioExecutor;
+use std::time::Duration;
 
 pub struct Configuration<C: Connect = HttpConnector>
 where
@@ -40,6 +41,7 @@ where
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,
     pub api_key: Option<ApiKey>,
+    pub timeout: Option<Duration>,
     // TODO: take an oauth2 token source, similar to the go one
 }
 
@@ -99,6 +101,7 @@ where
             basic_auth: None,
             oauth_access_token: None,
             api_key: None,
+            timeout: None,
         }
     }
 }

--- a/core/line_liff/src/apis/mod.rs
+++ b/core/line_liff/src/apis/mod.rs
@@ -30,6 +30,7 @@ pub enum Error {
     Hyper(hyper::Error),
     HyperClient(hyper_util::client::legacy::Error),
     Serde(serde_json::Error),
+    Timeout,
     UriError(http::uri::InvalidUri),
 }
 
@@ -65,6 +66,7 @@ impl fmt::Display for Error {
             Error::Hyper(e) => write!(f, "hyper error: {}", e),
             Error::HyperClient(e) => write!(f, "hyper client error: {}", e),
             Error::Serde(e) => write!(f, "serde error: {}", e),
+            Error::Timeout => write!(f, "request timed out"),
             Error::UriError(e) => write!(f, "URI error: {}", e),
         }
     }

--- a/core/line_liff/src/apis/request.rs
+++ b/core/line_liff/src/apis/request.rs
@@ -240,41 +240,45 @@ impl Request {
         };
 
         let no_return_type = self.no_return_type;
-        Box::pin(
-            conf.client
-                .request(request)
-                .map_err(|e| Error::from(e))
-                .and_then(move |response| {
-                    let status = response.status();
-                    if !status.is_success() {
-                        futures::future::err::<U, Error>(Error::from((
-                            status,
-                            response.into_body(),
-                        )))
+        let timeout_duration = conf.timeout;
+        let fut = conf
+            .client
+            .request(request)
+            .map_err(|e| Error::from(e))
+            .and_then(move |response| {
+                let status = response.status();
+                if !status.is_success() {
+                    futures::future::err::<U, Error>(Error::from((status, response.into_body())))
                         .boxed()
-                    } else if no_return_type {
-                        // This is a hack; if there's no_ret_type, U is (), but serde_json gives an
-                        // error when deserializing "" into (), so deserialize 'null' into it
-                        // instead.
-                        // An alternate option would be to require U: Default, and then return
-                        // U::default() here instead since () implements that, but then we'd
-                        // need to impl default for all models.
-                        futures::future::ok::<U, Error>(
-                            serde_json::from_str("null").expect("serde null value"),
-                        )
-                        .boxed()
-                    } else {
-                        let collect = response.into_body().collect().map_err(Error::from);
-                        collect
-                            .map(|collected| {
-                                collected.and_then(|collected| {
-                                    serde_json::from_slice(&collected.to_bytes())
-                                        .map_err(Error::from)
-                                })
+                } else if no_return_type {
+                    // This is a hack; if there's no_ret_type, U is (), but serde_json gives an
+                    // error when deserializing "" into (), so deserialize 'null' into it
+                    // instead.
+                    // An alternate option would be to require U: Default, and then return
+                    // U::default() here instead since () implements that, but then we'd
+                    // need to impl default for all models.
+                    futures::future::ok::<U, Error>(
+                        serde_json::from_str("null").expect("serde null value"),
+                    )
+                    .boxed()
+                } else {
+                    let collect = response.into_body().collect().map_err(Error::from);
+                    collect
+                        .map(|collected| {
+                            collected.and_then(|collected| {
+                                serde_json::from_slice(&collected.to_bytes()).map_err(Error::from)
                             })
-                            .boxed()
-                    }
-                }),
-        )
+                        })
+                        .boxed()
+                }
+            });
+        match timeout_duration {
+            Some(d) => Box::pin(async move {
+                tokio::time::timeout(d, fut)
+                    .await
+                    .unwrap_or(Err(Error::Timeout))
+            }),
+            None => Box::pin(fut),
+        }
     }
 }

--- a/core/line_manage_audience/Cargo.toml
+++ b/core/line_manage_audience/Cargo.toml
@@ -18,6 +18,7 @@ hyper-util = { workspace = true, features = ["client", "client-legacy", "http1",
 http-body-util.workspace = true
 base64.workspace = true
 futures.workspace = true
+tokio = { workspace = true, features = ["time"] }
 
 [lints]
 workspace = true

--- a/core/line_manage_audience/src/apis/configuration.rs
+++ b/core/line_manage_audience/src/apis/configuration.rs
@@ -29,6 +29,7 @@ use hyper_util::client::legacy::connect::Connect;
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::client::legacy::Client;
 use hyper_util::rt::TokioExecutor;
+use std::time::Duration;
 
 pub struct Configuration<C: Connect = HttpConnector>
 where
@@ -40,6 +41,7 @@ where
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,
     pub api_key: Option<ApiKey>,
+    pub timeout: Option<Duration>,
     // TODO: take an oauth2 token source, similar to the go one
 }
 
@@ -99,6 +101,7 @@ where
             basic_auth: None,
             oauth_access_token: None,
             api_key: None,
+            timeout: None,
         }
     }
 }

--- a/core/line_manage_audience/src/apis/mod.rs
+++ b/core/line_manage_audience/src/apis/mod.rs
@@ -30,6 +30,7 @@ pub enum Error {
     Hyper(hyper::Error),
     HyperClient(hyper_util::client::legacy::Error),
     Serde(serde_json::Error),
+    Timeout,
     UriError(http::uri::InvalidUri),
 }
 
@@ -65,6 +66,7 @@ impl fmt::Display for Error {
             Error::Hyper(e) => write!(f, "hyper error: {}", e),
             Error::HyperClient(e) => write!(f, "hyper client error: {}", e),
             Error::Serde(e) => write!(f, "serde error: {}", e),
+            Error::Timeout => write!(f, "request timed out"),
             Error::UriError(e) => write!(f, "URI error: {}", e),
         }
     }

--- a/core/line_manage_audience/src/apis/request.rs
+++ b/core/line_manage_audience/src/apis/request.rs
@@ -240,41 +240,45 @@ impl Request {
         };
 
         let no_return_type = self.no_return_type;
-        Box::pin(
-            conf.client
-                .request(request)
-                .map_err(|e| Error::from(e))
-                .and_then(move |response| {
-                    let status = response.status();
-                    if !status.is_success() {
-                        futures::future::err::<U, Error>(Error::from((
-                            status,
-                            response.into_body(),
-                        )))
+        let timeout_duration = conf.timeout;
+        let fut = conf
+            .client
+            .request(request)
+            .map_err(|e| Error::from(e))
+            .and_then(move |response| {
+                let status = response.status();
+                if !status.is_success() {
+                    futures::future::err::<U, Error>(Error::from((status, response.into_body())))
                         .boxed()
-                    } else if no_return_type {
-                        // This is a hack; if there's no_ret_type, U is (), but serde_json gives an
-                        // error when deserializing "" into (), so deserialize 'null' into it
-                        // instead.
-                        // An alternate option would be to require U: Default, and then return
-                        // U::default() here instead since () implements that, but then we'd
-                        // need to impl default for all models.
-                        futures::future::ok::<U, Error>(
-                            serde_json::from_str("null").expect("serde null value"),
-                        )
-                        .boxed()
-                    } else {
-                        let collect = response.into_body().collect().map_err(Error::from);
-                        collect
-                            .map(|collected| {
-                                collected.and_then(|collected| {
-                                    serde_json::from_slice(&collected.to_bytes())
-                                        .map_err(Error::from)
-                                })
+                } else if no_return_type {
+                    // This is a hack; if there's no_ret_type, U is (), but serde_json gives an
+                    // error when deserializing "" into (), so deserialize 'null' into it
+                    // instead.
+                    // An alternate option would be to require U: Default, and then return
+                    // U::default() here instead since () implements that, but then we'd
+                    // need to impl default for all models.
+                    futures::future::ok::<U, Error>(
+                        serde_json::from_str("null").expect("serde null value"),
+                    )
+                    .boxed()
+                } else {
+                    let collect = response.into_body().collect().map_err(Error::from);
+                    collect
+                        .map(|collected| {
+                            collected.and_then(|collected| {
+                                serde_json::from_slice(&collected.to_bytes()).map_err(Error::from)
                             })
-                            .boxed()
-                    }
-                }),
-        )
+                        })
+                        .boxed()
+                }
+            });
+        match timeout_duration {
+            Some(d) => Box::pin(async move {
+                tokio::time::timeout(d, fut)
+                    .await
+                    .unwrap_or(Err(Error::Timeout))
+            }),
+            None => Box::pin(fut),
+        }
     }
 }

--- a/core/line_messaging_api/Cargo.toml
+++ b/core/line_messaging_api/Cargo.toml
@@ -18,6 +18,7 @@ hyper-util = { workspace = true, features = ["client", "client-legacy", "http1",
 http-body-util.workspace = true
 base64.workspace = true
 futures.workspace = true
+tokio = { workspace = true, features = ["time"] }
 
 [lints]
 workspace = true

--- a/core/line_messaging_api/src/apis/configuration.rs
+++ b/core/line_messaging_api/src/apis/configuration.rs
@@ -29,6 +29,7 @@ use hyper_util::client::legacy::connect::Connect;
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::client::legacy::Client;
 use hyper_util::rt::TokioExecutor;
+use std::time::Duration;
 
 pub struct Configuration<C: Connect = HttpConnector>
 where
@@ -40,6 +41,7 @@ where
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,
     pub api_key: Option<ApiKey>,
+    pub timeout: Option<Duration>,
     // TODO: take an oauth2 token source, similar to the go one
 }
 
@@ -99,6 +101,7 @@ where
             basic_auth: None,
             oauth_access_token: None,
             api_key: None,
+            timeout: None,
         }
     }
 }

--- a/core/line_messaging_api/src/apis/mod.rs
+++ b/core/line_messaging_api/src/apis/mod.rs
@@ -30,6 +30,7 @@ pub enum Error {
     Hyper(hyper::Error),
     HyperClient(hyper_util::client::legacy::Error),
     Serde(serde_json::Error),
+    Timeout,
     UriError(http::uri::InvalidUri),
 }
 
@@ -65,6 +66,7 @@ impl fmt::Display for Error {
             Error::Hyper(e) => write!(f, "hyper error: {}", e),
             Error::HyperClient(e) => write!(f, "hyper client error: {}", e),
             Error::Serde(e) => write!(f, "serde error: {}", e),
+            Error::Timeout => write!(f, "request timed out"),
             Error::UriError(e) => write!(f, "URI error: {}", e),
         }
     }

--- a/core/line_messaging_api/src/apis/request.rs
+++ b/core/line_messaging_api/src/apis/request.rs
@@ -240,41 +240,45 @@ impl Request {
         };
 
         let no_return_type = self.no_return_type;
-        Box::pin(
-            conf.client
-                .request(request)
-                .map_err(|e| Error::from(e))
-                .and_then(move |response| {
-                    let status = response.status();
-                    if !status.is_success() {
-                        futures::future::err::<U, Error>(Error::from((
-                            status,
-                            response.into_body(),
-                        )))
+        let timeout_duration = conf.timeout;
+        let fut = conf
+            .client
+            .request(request)
+            .map_err(|e| Error::from(e))
+            .and_then(move |response| {
+                let status = response.status();
+                if !status.is_success() {
+                    futures::future::err::<U, Error>(Error::from((status, response.into_body())))
                         .boxed()
-                    } else if no_return_type {
-                        // This is a hack; if there's no_ret_type, U is (), but serde_json gives an
-                        // error when deserializing "" into (), so deserialize 'null' into it
-                        // instead.
-                        // An alternate option would be to require U: Default, and then return
-                        // U::default() here instead since () implements that, but then we'd
-                        // need to impl default for all models.
-                        futures::future::ok::<U, Error>(
-                            serde_json::from_str("null").expect("serde null value"),
-                        )
-                        .boxed()
-                    } else {
-                        let collect = response.into_body().collect().map_err(Error::from);
-                        collect
-                            .map(|collected| {
-                                collected.and_then(|collected| {
-                                    serde_json::from_slice(&collected.to_bytes())
-                                        .map_err(Error::from)
-                                })
+                } else if no_return_type {
+                    // This is a hack; if there's no_ret_type, U is (), but serde_json gives an
+                    // error when deserializing "" into (), so deserialize 'null' into it
+                    // instead.
+                    // An alternate option would be to require U: Default, and then return
+                    // U::default() here instead since () implements that, but then we'd
+                    // need to impl default for all models.
+                    futures::future::ok::<U, Error>(
+                        serde_json::from_str("null").expect("serde null value"),
+                    )
+                    .boxed()
+                } else {
+                    let collect = response.into_body().collect().map_err(Error::from);
+                    collect
+                        .map(|collected| {
+                            collected.and_then(|collected| {
+                                serde_json::from_slice(&collected.to_bytes()).map_err(Error::from)
                             })
-                            .boxed()
-                    }
-                }),
-        )
+                        })
+                        .boxed()
+                }
+            });
+        match timeout_duration {
+            Some(d) => Box::pin(async move {
+                tokio::time::timeout(d, fut)
+                    .await
+                    .unwrap_or(Err(Error::Timeout))
+            }),
+            None => Box::pin(fut),
+        }
     }
 }

--- a/core/line_module/Cargo.toml
+++ b/core/line_module/Cargo.toml
@@ -17,6 +17,7 @@ hyper-util = { workspace = true, features = ["client", "client-legacy", "http1",
 http-body-util.workspace = true
 base64.workspace = true
 futures.workspace = true
+tokio = { workspace = true, features = ["time"] }
 
 [lints]
 workspace = true

--- a/core/line_module/src/apis/configuration.rs
+++ b/core/line_module/src/apis/configuration.rs
@@ -29,6 +29,7 @@ use hyper_util::client::legacy::connect::Connect;
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::client::legacy::Client;
 use hyper_util::rt::TokioExecutor;
+use std::time::Duration;
 
 pub struct Configuration<C: Connect = HttpConnector>
 where
@@ -40,6 +41,7 @@ where
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,
     pub api_key: Option<ApiKey>,
+    pub timeout: Option<Duration>,
     // TODO: take an oauth2 token source, similar to the go one
 }
 
@@ -99,6 +101,7 @@ where
             basic_auth: None,
             oauth_access_token: None,
             api_key: None,
+            timeout: None,
         }
     }
 }

--- a/core/line_module/src/apis/mod.rs
+++ b/core/line_module/src/apis/mod.rs
@@ -30,6 +30,7 @@ pub enum Error {
     Hyper(hyper::Error),
     HyperClient(hyper_util::client::legacy::Error),
     Serde(serde_json::Error),
+    Timeout,
     UriError(http::uri::InvalidUri),
 }
 
@@ -65,6 +66,7 @@ impl fmt::Display for Error {
             Error::Hyper(e) => write!(f, "hyper error: {}", e),
             Error::HyperClient(e) => write!(f, "hyper client error: {}", e),
             Error::Serde(e) => write!(f, "serde error: {}", e),
+            Error::Timeout => write!(f, "request timed out"),
             Error::UriError(e) => write!(f, "URI error: {}", e),
         }
     }

--- a/core/line_module/src/apis/request.rs
+++ b/core/line_module/src/apis/request.rs
@@ -240,41 +240,45 @@ impl Request {
         };
 
         let no_return_type = self.no_return_type;
-        Box::pin(
-            conf.client
-                .request(request)
-                .map_err(|e| Error::from(e))
-                .and_then(move |response| {
-                    let status = response.status();
-                    if !status.is_success() {
-                        futures::future::err::<U, Error>(Error::from((
-                            status,
-                            response.into_body(),
-                        )))
+        let timeout_duration = conf.timeout;
+        let fut = conf
+            .client
+            .request(request)
+            .map_err(|e| Error::from(e))
+            .and_then(move |response| {
+                let status = response.status();
+                if !status.is_success() {
+                    futures::future::err::<U, Error>(Error::from((status, response.into_body())))
                         .boxed()
-                    } else if no_return_type {
-                        // This is a hack; if there's no_ret_type, U is (), but serde_json gives an
-                        // error when deserializing "" into (), so deserialize 'null' into it
-                        // instead.
-                        // An alternate option would be to require U: Default, and then return
-                        // U::default() here instead since () implements that, but then we'd
-                        // need to impl default for all models.
-                        futures::future::ok::<U, Error>(
-                            serde_json::from_str("null").expect("serde null value"),
-                        )
-                        .boxed()
-                    } else {
-                        let collect = response.into_body().collect().map_err(Error::from);
-                        collect
-                            .map(|collected| {
-                                collected.and_then(|collected| {
-                                    serde_json::from_slice(&collected.to_bytes())
-                                        .map_err(Error::from)
-                                })
+                } else if no_return_type {
+                    // This is a hack; if there's no_ret_type, U is (), but serde_json gives an
+                    // error when deserializing "" into (), so deserialize 'null' into it
+                    // instead.
+                    // An alternate option would be to require U: Default, and then return
+                    // U::default() here instead since () implements that, but then we'd
+                    // need to impl default for all models.
+                    futures::future::ok::<U, Error>(
+                        serde_json::from_str("null").expect("serde null value"),
+                    )
+                    .boxed()
+                } else {
+                    let collect = response.into_body().collect().map_err(Error::from);
+                    collect
+                        .map(|collected| {
+                            collected.and_then(|collected| {
+                                serde_json::from_slice(&collected.to_bytes()).map_err(Error::from)
                             })
-                            .boxed()
-                    }
-                }),
-        )
+                        })
+                        .boxed()
+                }
+            });
+        match timeout_duration {
+            Some(d) => Box::pin(async move {
+                tokio::time::timeout(d, fut)
+                    .await
+                    .unwrap_or(Err(Error::Timeout))
+            }),
+            None => Box::pin(fut),
+        }
     }
 }

--- a/core/line_module_attach/Cargo.toml
+++ b/core/line_module_attach/Cargo.toml
@@ -17,6 +17,7 @@ hyper-util = { workspace = true, features = ["client", "client-legacy", "http1",
 http-body-util.workspace = true
 base64.workspace = true
 futures.workspace = true
+tokio = { workspace = true, features = ["time"] }
 
 [lints]
 workspace = true

--- a/core/line_module_attach/src/apis/configuration.rs
+++ b/core/line_module_attach/src/apis/configuration.rs
@@ -29,6 +29,7 @@ use hyper_util::client::legacy::connect::Connect;
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::client::legacy::Client;
 use hyper_util::rt::TokioExecutor;
+use std::time::Duration;
 
 pub struct Configuration<C: Connect = HttpConnector>
 where
@@ -40,6 +41,7 @@ where
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,
     pub api_key: Option<ApiKey>,
+    pub timeout: Option<Duration>,
     // TODO: take an oauth2 token source, similar to the go one
 }
 
@@ -99,6 +101,7 @@ where
             basic_auth: None,
             oauth_access_token: None,
             api_key: None,
+            timeout: None,
         }
     }
 }

--- a/core/line_module_attach/src/apis/mod.rs
+++ b/core/line_module_attach/src/apis/mod.rs
@@ -30,6 +30,7 @@ pub enum Error {
     Hyper(hyper::Error),
     HyperClient(hyper_util::client::legacy::Error),
     Serde(serde_json::Error),
+    Timeout,
     UriError(http::uri::InvalidUri),
 }
 
@@ -65,6 +66,7 @@ impl fmt::Display for Error {
             Error::Hyper(e) => write!(f, "hyper error: {}", e),
             Error::HyperClient(e) => write!(f, "hyper client error: {}", e),
             Error::Serde(e) => write!(f, "serde error: {}", e),
+            Error::Timeout => write!(f, "request timed out"),
             Error::UriError(e) => write!(f, "URI error: {}", e),
         }
     }

--- a/core/line_module_attach/src/apis/request.rs
+++ b/core/line_module_attach/src/apis/request.rs
@@ -240,41 +240,45 @@ impl Request {
         };
 
         let no_return_type = self.no_return_type;
-        Box::pin(
-            conf.client
-                .request(request)
-                .map_err(|e| Error::from(e))
-                .and_then(move |response| {
-                    let status = response.status();
-                    if !status.is_success() {
-                        futures::future::err::<U, Error>(Error::from((
-                            status,
-                            response.into_body(),
-                        )))
+        let timeout_duration = conf.timeout;
+        let fut = conf
+            .client
+            .request(request)
+            .map_err(|e| Error::from(e))
+            .and_then(move |response| {
+                let status = response.status();
+                if !status.is_success() {
+                    futures::future::err::<U, Error>(Error::from((status, response.into_body())))
                         .boxed()
-                    } else if no_return_type {
-                        // This is a hack; if there's no_ret_type, U is (), but serde_json gives an
-                        // error when deserializing "" into (), so deserialize 'null' into it
-                        // instead.
-                        // An alternate option would be to require U: Default, and then return
-                        // U::default() here instead since () implements that, but then we'd
-                        // need to impl default for all models.
-                        futures::future::ok::<U, Error>(
-                            serde_json::from_str("null").expect("serde null value"),
-                        )
-                        .boxed()
-                    } else {
-                        let collect = response.into_body().collect().map_err(Error::from);
-                        collect
-                            .map(|collected| {
-                                collected.and_then(|collected| {
-                                    serde_json::from_slice(&collected.to_bytes())
-                                        .map_err(Error::from)
-                                })
+                } else if no_return_type {
+                    // This is a hack; if there's no_ret_type, U is (), but serde_json gives an
+                    // error when deserializing "" into (), so deserialize 'null' into it
+                    // instead.
+                    // An alternate option would be to require U: Default, and then return
+                    // U::default() here instead since () implements that, but then we'd
+                    // need to impl default for all models.
+                    futures::future::ok::<U, Error>(
+                        serde_json::from_str("null").expect("serde null value"),
+                    )
+                    .boxed()
+                } else {
+                    let collect = response.into_body().collect().map_err(Error::from);
+                    collect
+                        .map(|collected| {
+                            collected.and_then(|collected| {
+                                serde_json::from_slice(&collected.to_bytes()).map_err(Error::from)
                             })
-                            .boxed()
-                    }
-                }),
-        )
+                        })
+                        .boxed()
+                }
+            });
+        match timeout_duration {
+            Some(d) => Box::pin(async move {
+                tokio::time::timeout(d, fut)
+                    .await
+                    .unwrap_or(Err(Error::Timeout))
+            }),
+            None => Box::pin(fut),
+        }
     }
 }

--- a/core/line_shop/Cargo.toml
+++ b/core/line_shop/Cargo.toml
@@ -17,6 +17,7 @@ hyper-util = { workspace = true, features = ["client", "client-legacy", "http1",
 http-body-util.workspace = true
 base64.workspace = true
 futures.workspace = true
+tokio = { workspace = true, features = ["time"] }
 
 [lints]
 workspace = true

--- a/core/line_shop/src/apis/configuration.rs
+++ b/core/line_shop/src/apis/configuration.rs
@@ -29,6 +29,7 @@ use hyper_util::client::legacy::connect::Connect;
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::client::legacy::Client;
 use hyper_util::rt::TokioExecutor;
+use std::time::Duration;
 
 pub struct Configuration<C: Connect = HttpConnector>
 where
@@ -40,6 +41,7 @@ where
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,
     pub api_key: Option<ApiKey>,
+    pub timeout: Option<Duration>,
     // TODO: take an oauth2 token source, similar to the go one
 }
 
@@ -99,6 +101,7 @@ where
             basic_auth: None,
             oauth_access_token: None,
             api_key: None,
+            timeout: None,
         }
     }
 }

--- a/core/line_shop/src/apis/mod.rs
+++ b/core/line_shop/src/apis/mod.rs
@@ -30,6 +30,7 @@ pub enum Error {
     Hyper(hyper::Error),
     HyperClient(hyper_util::client::legacy::Error),
     Serde(serde_json::Error),
+    Timeout,
     UriError(http::uri::InvalidUri),
 }
 
@@ -65,6 +66,7 @@ impl fmt::Display for Error {
             Error::Hyper(e) => write!(f, "hyper error: {}", e),
             Error::HyperClient(e) => write!(f, "hyper client error: {}", e),
             Error::Serde(e) => write!(f, "serde error: {}", e),
+            Error::Timeout => write!(f, "request timed out"),
             Error::UriError(e) => write!(f, "URI error: {}", e),
         }
     }

--- a/core/line_shop/src/apis/request.rs
+++ b/core/line_shop/src/apis/request.rs
@@ -240,41 +240,45 @@ impl Request {
         };
 
         let no_return_type = self.no_return_type;
-        Box::pin(
-            conf.client
-                .request(request)
-                .map_err(|e| Error::from(e))
-                .and_then(move |response| {
-                    let status = response.status();
-                    if !status.is_success() {
-                        futures::future::err::<U, Error>(Error::from((
-                            status,
-                            response.into_body(),
-                        )))
+        let timeout_duration = conf.timeout;
+        let fut = conf
+            .client
+            .request(request)
+            .map_err(|e| Error::from(e))
+            .and_then(move |response| {
+                let status = response.status();
+                if !status.is_success() {
+                    futures::future::err::<U, Error>(Error::from((status, response.into_body())))
                         .boxed()
-                    } else if no_return_type {
-                        // This is a hack; if there's no_ret_type, U is (), but serde_json gives an
-                        // error when deserializing "" into (), so deserialize 'null' into it
-                        // instead.
-                        // An alternate option would be to require U: Default, and then return
-                        // U::default() here instead since () implements that, but then we'd
-                        // need to impl default for all models.
-                        futures::future::ok::<U, Error>(
-                            serde_json::from_str("null").expect("serde null value"),
-                        )
-                        .boxed()
-                    } else {
-                        let collect = response.into_body().collect().map_err(Error::from);
-                        collect
-                            .map(|collected| {
-                                collected.and_then(|collected| {
-                                    serde_json::from_slice(&collected.to_bytes())
-                                        .map_err(Error::from)
-                                })
+                } else if no_return_type {
+                    // This is a hack; if there's no_ret_type, U is (), but serde_json gives an
+                    // error when deserializing "" into (), so deserialize 'null' into it
+                    // instead.
+                    // An alternate option would be to require U: Default, and then return
+                    // U::default() here instead since () implements that, but then we'd
+                    // need to impl default for all models.
+                    futures::future::ok::<U, Error>(
+                        serde_json::from_str("null").expect("serde null value"),
+                    )
+                    .boxed()
+                } else {
+                    let collect = response.into_body().collect().map_err(Error::from);
+                    collect
+                        .map(|collected| {
+                            collected.and_then(|collected| {
+                                serde_json::from_slice(&collected.to_bytes()).map_err(Error::from)
                             })
-                            .boxed()
-                    }
-                }),
-        )
+                        })
+                        .boxed()
+                }
+            });
+        match timeout_duration {
+            Some(d) => Box::pin(async move {
+                tokio::time::timeout(d, fut)
+                    .await
+                    .unwrap_or(Err(Error::Timeout))
+            }),
+            None => Box::pin(fut),
+        }
     }
 }

--- a/core/line_webhook/Cargo.toml
+++ b/core/line_webhook/Cargo.toml
@@ -17,6 +17,7 @@ hyper-util = { workspace = true, features = ["client", "client-legacy", "http1",
 http-body-util.workspace = true
 base64.workspace = true
 futures.workspace = true
+tokio = { workspace = true, features = ["time"] }
 
 [lints]
 workspace = true

--- a/core/line_webhook/src/apis/configuration.rs
+++ b/core/line_webhook/src/apis/configuration.rs
@@ -29,6 +29,7 @@ use hyper_util::client::legacy::connect::Connect;
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::client::legacy::Client;
 use hyper_util::rt::TokioExecutor;
+use std::time::Duration;
 
 pub struct Configuration<C: Connect = HttpConnector>
 where
@@ -40,6 +41,7 @@ where
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,
     pub api_key: Option<ApiKey>,
+    pub timeout: Option<Duration>,
     // TODO: take an oauth2 token source, similar to the go one
 }
 
@@ -99,6 +101,7 @@ where
             basic_auth: None,
             oauth_access_token: None,
             api_key: None,
+            timeout: None,
         }
     }
 }

--- a/core/line_webhook/src/apis/mod.rs
+++ b/core/line_webhook/src/apis/mod.rs
@@ -30,6 +30,7 @@ pub enum Error {
     Hyper(hyper::Error),
     HyperClient(hyper_util::client::legacy::Error),
     Serde(serde_json::Error),
+    Timeout,
     UriError(http::uri::InvalidUri),
 }
 
@@ -65,6 +66,7 @@ impl fmt::Display for Error {
             Error::Hyper(e) => write!(f, "hyper error: {}", e),
             Error::HyperClient(e) => write!(f, "hyper client error: {}", e),
             Error::Serde(e) => write!(f, "serde error: {}", e),
+            Error::Timeout => write!(f, "request timed out"),
             Error::UriError(e) => write!(f, "URI error: {}", e),
         }
     }

--- a/core/line_webhook/src/apis/request.rs
+++ b/core/line_webhook/src/apis/request.rs
@@ -240,41 +240,45 @@ impl Request {
         };
 
         let no_return_type = self.no_return_type;
-        Box::pin(
-            conf.client
-                .request(request)
-                .map_err(|e| Error::from(e))
-                .and_then(move |response| {
-                    let status = response.status();
-                    if !status.is_success() {
-                        futures::future::err::<U, Error>(Error::from((
-                            status,
-                            response.into_body(),
-                        )))
+        let timeout_duration = conf.timeout;
+        let fut = conf
+            .client
+            .request(request)
+            .map_err(|e| Error::from(e))
+            .and_then(move |response| {
+                let status = response.status();
+                if !status.is_success() {
+                    futures::future::err::<U, Error>(Error::from((status, response.into_body())))
                         .boxed()
-                    } else if no_return_type {
-                        // This is a hack; if there's no_ret_type, U is (), but serde_json gives an
-                        // error when deserializing "" into (), so deserialize 'null' into it
-                        // instead.
-                        // An alternate option would be to require U: Default, and then return
-                        // U::default() here instead since () implements that, but then we'd
-                        // need to impl default for all models.
-                        futures::future::ok::<U, Error>(
-                            serde_json::from_str("null").expect("serde null value"),
-                        )
-                        .boxed()
-                    } else {
-                        let collect = response.into_body().collect().map_err(Error::from);
-                        collect
-                            .map(|collected| {
-                                collected.and_then(|collected| {
-                                    serde_json::from_slice(&collected.to_bytes())
-                                        .map_err(Error::from)
-                                })
+                } else if no_return_type {
+                    // This is a hack; if there's no_ret_type, U is (), but serde_json gives an
+                    // error when deserializing "" into (), so deserialize 'null' into it
+                    // instead.
+                    // An alternate option would be to require U: Default, and then return
+                    // U::default() here instead since () implements that, but then we'd
+                    // need to impl default for all models.
+                    futures::future::ok::<U, Error>(
+                        serde_json::from_str("null").expect("serde null value"),
+                    )
+                    .boxed()
+                } else {
+                    let collect = response.into_body().collect().map_err(Error::from);
+                    collect
+                        .map(|collected| {
+                            collected.and_then(|collected| {
+                                serde_json::from_slice(&collected.to_bytes()).map_err(Error::from)
                             })
-                            .boxed()
-                    }
-                }),
-        )
+                        })
+                        .boxed()
+                }
+            });
+        match timeout_duration {
+            Some(d) => Box::pin(async move {
+                tokio::time::timeout(d, fut)
+                    .await
+                    .unwrap_or(Err(Error::Timeout))
+            }),
+            None => Box::pin(fut),
+        }
     }
 }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
 resolver = "2"
-members = ["actix_web_example", "rocket_example"]
+members = ["actix_web_example", "axum_example", "rocket_example"]

--- a/examples/axum_example/Cargo.toml
+++ b/examples/axum_example/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "axum_example"
+version = "0.1.0"
+edition = "2021"
+workspace = "../"
+publish = false
+
+[dependencies]
+axum = "0.8"
+dotenvy = "0.15.7"
+serde_json = "1.0.149"
+tokio = { version = "1", features = ["full"] }
+
+[dependencies.line-bot-sdk-rust]
+path = "../../core/lib"
+features = ["axum_support"]

--- a/examples/axum_example/src/main.rs
+++ b/examples/axum_example/src/main.rs
@@ -1,0 +1,76 @@
+use axum::{routing::post, Router};
+use dotenvy::dotenv;
+use line_bot_sdk_rust::{
+    client::LINE,
+    line_messaging_api::{
+        apis::MessagingApiApi,
+        models::{Message, ReplyMessageRequest, TextMessage},
+    },
+    line_webhook::models::{CallbackRequest, Event, MessageContent},
+    parser::signature::validate_signature,
+    support::axum::Signature,
+};
+use std::env;
+
+async fn callback(
+    signature: Signature,
+    body: String,
+) -> Result<&'static str, (axum::http::StatusCode, String)> {
+    let channel_secret =
+        env::var("LINE_CHANNEL_SECRET").expect("Failed to get LINE_CHANNEL_SECRET");
+    let access_token =
+        env::var("LINE_CHANNEL_ACCESS_TOKEN").expect("Failed to get LINE_CHANNEL_ACCESS_TOKEN");
+
+    let line = LINE::new(access_token);
+
+    if !validate_signature(&channel_secret, &signature.key, &body) {
+        return Err((
+            axum::http::StatusCode::BAD_REQUEST,
+            "x-line-signature is invalid.".to_string(),
+        ));
+    }
+
+    let request: CallbackRequest = serde_json::from_str(&body).map_err(|e| {
+        (
+            axum::http::StatusCode::BAD_REQUEST,
+            format!("JSON parse error: {e}"),
+        )
+    })?;
+
+    println!("req: {request:#?}");
+
+    for e in request.events {
+        if let Event::MessageEvent(message_event) = e {
+            if let MessageContent::TextMessageContent(text_message) = *message_event.message {
+                let reply_message_request = ReplyMessageRequest {
+                    reply_token: message_event.reply_token.unwrap(),
+                    messages: vec![Message::Text(TextMessage::new(text_message.text))],
+                    notification_disabled: Some(false),
+                };
+                let result = line
+                    .messaging_api_client
+                    .reply_message(reply_message_request)
+                    .await;
+                match result {
+                    Ok(r) => println!("{r:#?}"),
+                    Err(e) => println!("{e:#?}"),
+                }
+            }
+        }
+    }
+
+    Ok("ok")
+}
+
+#[tokio::main]
+async fn main() {
+    dotenv().ok();
+
+    let app = Router::new().route("/callback", post(callback));
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:8080")
+        .await
+        .unwrap();
+    println!("Listening on {}", listener.local_addr().unwrap());
+    axum::serve(listener, app).await.unwrap();
+}

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -269,13 +269,15 @@ fn fix_timeout_support(pkg_dir: &str) {
     if request_path.exists() {
         let mut contents = read_file(&request_path);
         if !contents.contains("timeout") {
+            // Replace Box::pin(conf.client... with let fut = conf.client...
             contents = contents.replace(
-                "let no_return_type = self.no_return_type;\n        Box::pin(\n            conf.client\n                .request(request)\n                .map_err(|e| Error::from(e))\n                .and_then(",
-                "let no_return_type = self.no_return_type;\n        let timeout_duration = conf.timeout;\n        let fut = conf.client\n                .request(request)\n                .map_err(|e| Error::from(e))\n                .and_then(",
+                "Box::pin(conf.client\n            .request(request)\n            .map_err(|e| Error::from(e))\n            .and_then(",
+                "let timeout_duration = conf.timeout;\n        let fut = conf.client\n            .request(request)\n            .map_err(|e| Error::from(e))\n            .and_then(",
             );
+            // Replace })) (close and_then + Box::pin) with }); match ...
             contents = contents.replace(
-                "                }),\n        )\n    }\n}",
-                "                });\n        match timeout_duration {\n            Some(d) => Box::pin(async move {\n                tokio::time::timeout(d, fut)\n                    .await\n                    .unwrap_or(Err(Error::Timeout))\n            }),\n            None => Box::pin(fut),\n        }\n    }\n}",
+                "            }))\n    }\n}\n",
+                "            });\n        match timeout_duration {\n            Some(d) => Box::pin(async move {\n                tokio::time::timeout(d, fut)\n                    .await\n                    .unwrap_or(Err(Error::Timeout))\n            }),\n            None => Box::pin(fut),\n        }\n    }\n}\n",
             );
             write_file(&request_path, &contents);
         }

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -245,6 +245,69 @@ fn fix_workspace_lints(pkg_dir: &str) {
     }
 }
 
+fn fix_timeout_support(pkg_dir: &str) {
+    // Add timeout field to Configuration
+    let config_path = Path::new(pkg_dir).join("src/apis/configuration.rs");
+    if config_path.exists() {
+        let mut contents = read_file(&config_path);
+        if !contents.contains("pub timeout: Option<Duration>,") {
+            contents = contents.replace("use hyper;", "use std::time::Duration;\nuse hyper;");
+            contents = contents.replace(
+                "pub api_key: Option<ApiKey>,",
+                "pub api_key: Option<ApiKey>,\n    pub timeout: Option<Duration>,",
+            );
+            contents = contents.replace(
+                "api_key: None,\n        }",
+                "api_key: None,\n            timeout: None,\n        }",
+            );
+            write_file(&config_path, &contents);
+        }
+    }
+
+    // Wrap request execution with timeout
+    let request_path = Path::new(pkg_dir).join("src/apis/request.rs");
+    if request_path.exists() {
+        let mut contents = read_file(&request_path);
+        if !contents.contains("timeout") {
+            contents = contents.replace(
+                "let no_return_type = self.no_return_type;\n        Box::pin(\n            conf.client\n                .request(request)\n                .map_err(|e| Error::from(e))\n                .and_then(",
+                "let no_return_type = self.no_return_type;\n        let timeout_duration = conf.timeout;\n        let fut = conf.client\n                .request(request)\n                .map_err(|e| Error::from(e))\n                .and_then(",
+            );
+            contents = contents.replace(
+                "                }),\n        )\n    }\n}",
+                "                });\n        match timeout_duration {\n            Some(d) => Box::pin(async move {\n                tokio::time::timeout(d, fut)\n                    .await\n                    .unwrap_or(Err(Error::Timeout))\n            }),\n            None => Box::pin(fut),\n        }\n    }\n}",
+            );
+            write_file(&request_path, &contents);
+        }
+    }
+
+    // Add Timeout variant to Error enum
+    let mod_path = Path::new(pkg_dir).join("src/apis/mod.rs");
+    if mod_path.exists() {
+        let mut contents = read_file(&mod_path);
+        if !contents.contains("Timeout") {
+            contents = contents.replace(
+                "UriError(http::uri::InvalidUri),",
+                "Timeout,\n    UriError(http::uri::InvalidUri),",
+            );
+            write_file(&mod_path, &contents);
+        }
+    }
+
+    // Add tokio dependency
+    let cargo_path = Path::new(pkg_dir).join("Cargo.toml");
+    if cargo_path.exists() {
+        let mut contents = read_file(&cargo_path);
+        if !contents.contains("tokio") {
+            contents = contents.replace(
+                "futures.workspace = true",
+                "futures.workspace = true\ntokio = { workspace = true, features = [\"time\"] }",
+            );
+            write_file(&cargo_path, &contents);
+        }
+    }
+}
+
 fn fix_error_type(pkg_dir: &str) {
     let mod_rs_path = Path::new(pkg_dir).join("src/apis/mod.rs");
     if !mod_rs_path.exists() {
@@ -267,6 +330,7 @@ fn fix_error_type(pkg_dir: &str) {
             Error::Hyper(e) => write!(f, "hyper error: {}", e),
             Error::HyperClient(e) => write!(f, "hyper client error: {}", e),
             Error::Serde(e) => write!(f, "serde error: {}", e),
+            Error::Timeout => write!(f, "request timed out"),
             Error::UriError(e) => write!(f, "URI error: {}", e),
         }
     }
@@ -471,6 +535,7 @@ fn main() {
         fix_workspace_dependencies(pkg_dir);
         fix_workspace_lints(pkg_dir);
         fix_extern_crates(pkg_dir);
+        fix_timeout_support(pkg_dir);
         fix_error_type(pkg_dir);
         fix_api_client_clone(pkg_dir);
     }


### PR DESCRIPTION
## Summary
- Add `axum_support` feature flag with `Signature` extractor for webhook signature validation
- Add configurable request timeout (`Configuration.timeout`) across all 9 generated crates
- Introduce `LINE::builder()` for setting timeout while keeping `LINE::new()` backward-compatible
- Add axum echo bot example, tests, and CI integration

## Details

### axum support
- `core/lib/src/support/axum.rs`: `Signature` extractor implementing `FromRequestParts`
- `core/lib/tests/axum_extractor.rs`: 3 tests
- `examples/axum_example/`: Echo bot example
- `.github/workflows/rust.yml`: clippy/build with `axum_support` feature
- MSRV bumped to 1.75.0 (required by axum 0.8 RPIT)

### Timeout
- All 9 generated crates: `Configuration.timeout: Option<Duration>` + `Error::Timeout`
- `request.rs`: wraps `conf.client.request()` with `tokio::time::timeout` when configured
- `generator/src/main.rs`: `fix_timeout_support()` for regeneration consistency
- `core/lib/src/client/mod.rs`: `LINE::builder(token).timeout(Duration::from_secs(30)).build()`

## Test plan
- [x] `cargo build` passes
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo clippy --features axum_support -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] Examples workspace builds
- [ ] CI check-generate passes (generator updated accordingly)

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)