### PR TITLE
Bump sub-crate versions, use official line-openapi

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -50,15 +50,10 @@ approach, or project structure, refer to these.
 
 ## line-openapi Submodule
 
-- Uses a fork (`nanato12/line-openapi`), NOT the official
-  `line/line-openapi`.
-- Reason: `info.version` in each YAML spec controls the
-  generated crate version in `Cargo.toml`. The fork allows
-  bumping versions independently for crates.io publishing.
-- Upstream: <https://github.com/line/line-openapi>
-- Fork: <https://github.com/nanato12/line-openapi>
-- Sync fork before generation:
-  `gh repo sync nanato12/line-openapi --source line/line-openapi --branch main`
+- Uses the official `line/line-openapi` repo.
+- Sub-crate versions are managed independently from the
+  OpenAPI spec `info.version`. The generator preserves
+  existing `Cargo.toml` versions across regeneration.
 - Submodule URL MUST use SSH (`git@github.com:`), not HTTPS.
 
 ## Code Generation

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "line-openapi"]
 	path = line-openapi
-	url = git@github.com:nanato12/line-openapi.git
+	url = git@github.com:line/line-openapi.git

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ publish:
 	cargo publish --manifest-path core/line_shop/Cargo.toml || true
 	cargo publish --manifest-path core/line_webhook/Cargo.toml || true
 	sleep 30
-	cargo publish --manifest-path core/lib/Cargo.toml
+	cargo publish --manifest-path core/lib/Cargo.toml --no-verify
 
 .PHONY: generate
 generate:

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ publish:
 	cargo publish --manifest-path core/line_shop/Cargo.toml || true
 	cargo publish --manifest-path core/line_webhook/Cargo.toml || true
 	sleep 30
-	cargo publish --manifest-path core/lib/Cargo.toml --no-verify
+	cargo publish --manifest-path core/lib/Cargo.toml
 
 .PHONY: generate
 generate:

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -44,39 +44,39 @@ optional = true
 default-features = false
 
 [dependencies.line_channel_access_token]
-version = "0.0.2"
+version = "0.0.3"
 path = "../line_channel_access_token"
 
 [dependencies.line_insight]
-version = "0.0.2"
+version = "0.0.3"
 path = "../line_insight"
 
 [dependencies.line_liff]
-version = "1.1.0"
+version = "1.2.0"
 path = "../line_liff"
 
 [dependencies.line_manage_audience]
-version = "0.0.2"
+version = "0.0.3"
 path = "../line_manage_audience"
 
 [dependencies.line_messaging_api]
-version = "0.0.4"
+version = "0.0.5"
 path = "../line_messaging_api"
 
 [dependencies.line_module]
-version = "0.0.2"
+version = "0.0.3"
 path = "../line_module"
 
 [dependencies.line_module_attach]
-version = "0.0.2"
+version = "0.0.3"
 path = "../line_module_attach"
 
 [dependencies.line_shop]
-version = "0.0.1"
+version = "0.0.2"
 path = "../line_shop"
 
 [dependencies.line_webhook]
-version = "1.0.2"
+version = "1.0.3"
 path = "../line_webhook"
 
 [dev-dependencies]

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -44,11 +44,11 @@ optional = true
 default-features = false
 
 [dependencies.line_channel_access_token]
-version = "0.0.3"
+version = "1.0.0"
 path = "../line_channel_access_token"
 
 [dependencies.line_insight]
-version = "0.0.3"
+version = "1.0.0"
 path = "../line_insight"
 
 [dependencies.line_liff]
@@ -56,23 +56,23 @@ version = "1.2.0"
 path = "../line_liff"
 
 [dependencies.line_manage_audience]
-version = "0.0.3"
+version = "1.0.0"
 path = "../line_manage_audience"
 
 [dependencies.line_messaging_api]
-version = "0.0.5"
+version = "1.0.0"
 path = "../line_messaging_api"
 
 [dependencies.line_module]
-version = "0.0.3"
+version = "1.0.0"
 path = "../line_module"
 
 [dependencies.line_module_attach]
-version = "0.0.3"
+version = "1.0.0"
 path = "../line_module_attach"
 
 [dependencies.line_shop]
-version = "0.0.2"
+version = "1.0.0"
 path = "../line_shop"
 
 [dependencies.line_webhook]

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -44,39 +44,39 @@ optional = true
 default-features = false
 
 [dependencies.line_channel_access_token]
-version = "0.0.3"
+version = "0.0.2"
 path = "../line_channel_access_token"
 
 [dependencies.line_insight]
-version = "0.0.3"
+version = "0.0.2"
 path = "../line_insight"
 
 [dependencies.line_liff]
-version = "1.2.0"
+version = "1.1.0"
 path = "../line_liff"
 
 [dependencies.line_manage_audience]
-version = "0.0.3"
+version = "0.0.2"
 path = "../line_manage_audience"
 
 [dependencies.line_messaging_api]
-version = "0.0.5"
+version = "0.0.4"
 path = "../line_messaging_api"
 
 [dependencies.line_module]
-version = "0.0.3"
+version = "0.0.2"
 path = "../line_module"
 
 [dependencies.line_module_attach]
-version = "0.0.3"
+version = "0.0.2"
 path = "../line_module_attach"
 
 [dependencies.line_shop]
-version = "0.0.2"
+version = "0.0.1"
 path = "../line_shop"
 
 [dependencies.line_webhook]
-version = "1.0.3"
+version = "1.0.2"
 path = "../line_webhook"
 
 [dev-dependencies]

--- a/core/line_channel_access_token/Cargo.toml
+++ b/core/line_channel_access_token/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "line_channel_access_token"
-version = "0.0.3"
+version = "0.0.2"
 authors = ["nanato12 <admin@okj.info>"]
 description = "This document describes Channel Access Token API."
 license = "Apache-2.0"

--- a/core/line_channel_access_token/Cargo.toml
+++ b/core/line_channel_access_token/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "line_channel_access_token"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["nanato12 <admin@okj.info>"]
 description = "This document describes Channel Access Token API."
 license = "Apache-2.0"

--- a/core/line_channel_access_token/Cargo.toml
+++ b/core/line_channel_access_token/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "line_channel_access_token"
-version = "0.0.3"
+version = "1.0.0"
 authors = ["nanato12 <admin@okj.info>"]
 description = "This document describes Channel Access Token API."
 license = "Apache-2.0"

--- a/core/line_insight/Cargo.toml
+++ b/core/line_insight/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "line_insight"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["nanato12 <admin@okj.info>"]
 description = "This document describes LINE Messaging API(Insight)."
 license = "Apache-2.0"

--- a/core/line_insight/Cargo.toml
+++ b/core/line_insight/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "line_insight"
-version = "0.0.3"
+version = "1.0.0"
 authors = ["nanato12 <admin@okj.info>"]
 description = "This document describes LINE Messaging API(Insight)."
 license = "Apache-2.0"

--- a/core/line_insight/Cargo.toml
+++ b/core/line_insight/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "line_insight"
-version = "0.0.3"
+version = "0.0.2"
 authors = ["nanato12 <admin@okj.info>"]
 description = "This document describes LINE Messaging API(Insight)."
 license = "Apache-2.0"

--- a/core/line_liff/Cargo.toml
+++ b/core/line_liff/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "line_liff"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["nanato12 <admin@okj.info>"]
 description = "LIFF Server API."
 license = "Apache-2.0"

--- a/core/line_liff/Cargo.toml
+++ b/core/line_liff/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "line_liff"
-version = "1.2.0"
+version = "1.1.0"
 authors = ["nanato12 <admin@okj.info>"]
 description = "LIFF Server API."
 license = "Apache-2.0"

--- a/core/line_manage_audience/Cargo.toml
+++ b/core/line_manage_audience/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "line_manage_audience"
-version = "0.0.3"
+version = "1.0.0"
 authors = ["nanato12 <admin@okj.info>"]
 description = "This document describes LINE Messaging API."
 license = "Apache-2.0"

--- a/core/line_manage_audience/Cargo.toml
+++ b/core/line_manage_audience/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "line_manage_audience"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["nanato12 <admin@okj.info>"]
 description = "This document describes LINE Messaging API."
 license = "Apache-2.0"

--- a/core/line_manage_audience/Cargo.toml
+++ b/core/line_manage_audience/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "line_manage_audience"
-version = "0.0.3"
+version = "0.0.2"
 authors = ["nanato12 <admin@okj.info>"]
 description = "This document describes LINE Messaging API."
 license = "Apache-2.0"

--- a/core/line_messaging_api/Cargo.toml
+++ b/core/line_messaging_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "line_messaging_api"
-version = "0.0.5"
+version = "0.0.4"
 authors = ["nanato12 <admin@okj.info>"]
 description = "This document describes LINE Messaging API."
 license = "Apache-2.0"

--- a/core/line_messaging_api/Cargo.toml
+++ b/core/line_messaging_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "line_messaging_api"
-version = "0.0.5"
+version = "1.0.0"
 authors = ["nanato12 <admin@okj.info>"]
 description = "This document describes LINE Messaging API."
 license = "Apache-2.0"

--- a/core/line_messaging_api/Cargo.toml
+++ b/core/line_messaging_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "line_messaging_api"
-version = "0.0.4"
+version = "0.0.5"
 authors = ["nanato12 <admin@okj.info>"]
 description = "This document describes LINE Messaging API."
 license = "Apache-2.0"

--- a/core/line_module/Cargo.toml
+++ b/core/line_module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "line_module"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["nanato12 <admin@okj.info>"]
 description = "This document describes LINE Messaging API."
 license = "Apache-2.0"

--- a/core/line_module/Cargo.toml
+++ b/core/line_module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "line_module"
-version = "0.0.3"
+version = "1.0.0"
 authors = ["nanato12 <admin@okj.info>"]
 description = "This document describes LINE Messaging API."
 license = "Apache-2.0"

--- a/core/line_module/Cargo.toml
+++ b/core/line_module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "line_module"
-version = "0.0.3"
+version = "0.0.2"
 authors = ["nanato12 <admin@okj.info>"]
 description = "This document describes LINE Messaging API."
 license = "Apache-2.0"

--- a/core/line_module_attach/Cargo.toml
+++ b/core/line_module_attach/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "line_module_attach"
-version = "0.0.3"
+version = "1.0.0"
 authors = ["nanato12 <admin@okj.info>"]
 description = "This document describes LINE Messaging API."
 license = "Apache-2.0"

--- a/core/line_module_attach/Cargo.toml
+++ b/core/line_module_attach/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "line_module_attach"
-version = "0.0.3"
+version = "0.0.2"
 authors = ["nanato12 <admin@okj.info>"]
 description = "This document describes LINE Messaging API."
 license = "Apache-2.0"

--- a/core/line_module_attach/Cargo.toml
+++ b/core/line_module_attach/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "line_module_attach"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["nanato12 <admin@okj.info>"]
 description = "This document describes LINE Messaging API."
 license = "Apache-2.0"

--- a/core/line_shop/Cargo.toml
+++ b/core/line_shop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "line_shop"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["nanato12 <admin@okj.info>"]
 description = "This document describes LINE Mission Stickers API."
 license = "Apache-2.0"

--- a/core/line_shop/Cargo.toml
+++ b/core/line_shop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "line_shop"
-version = "0.0.2"
+version = "1.0.0"
 authors = ["nanato12 <admin@okj.info>"]
 description = "This document describes LINE Mission Stickers API."
 license = "Apache-2.0"

--- a/core/line_shop/Cargo.toml
+++ b/core/line_shop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "line_shop"
-version = "0.0.2"
+version = "0.0.1"
 authors = ["nanato12 <admin@okj.info>"]
 description = "This document describes LINE Mission Stickers API."
 license = "Apache-2.0"

--- a/core/line_webhook/Cargo.toml
+++ b/core/line_webhook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "line_webhook"
-version = "1.0.3"
+version = "1.0.2"
 authors = ["nanato12 <admin@okj.info>"]
 description = "Webhook event definition of the LINE Messaging API"
 license = "Apache-2.0"

--- a/core/line_webhook/Cargo.toml
+++ b/core/line_webhook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "line_webhook"
-version = "1.0.2"
+version = "1.0.3"
 authors = ["nanato12 <admin@okj.info>"]
 description = "Webhook event definition of the LINE Messaging API"
 license = "Apache-2.0"

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -479,6 +479,23 @@ fn main() {
         let pkg_name = &format!("{PKG_NAME_PREFIX}_{}", service.replace("-", "_"));
         let pkg_dir = &format!("{OUTPUT_DIR}/{pkg_name}");
 
+        // Preserve existing version from Cargo.toml before regeneration
+        // (sub-crate versions are managed independently from OpenAPI spec versions)
+        let existing_version = {
+            let cargo_toml_path = Path::new(pkg_dir).join("Cargo.toml");
+            if cargo_toml_path.exists() {
+                let contents = read_file(&cargo_toml_path);
+                contents
+                    .lines()
+                    .find(|l| l.starts_with("version = "))
+                    .and_then(|l| l.strip_prefix("version = \""))
+                    .and_then(|l| l.strip_suffix('"'))
+                    .map(|v| v.to_string())
+            } else {
+                None
+            }
+        };
+
         // Initialize package directory (preserve hand-written tests/)
         let tests_dir = Path::new(pkg_dir).join("tests");
         let tests_backup = Path::new(pkg_dir).with_file_name(format!("{pkg_name}_tests_backup"));
@@ -533,6 +550,25 @@ fn main() {
 
         process_directory(&PathBuf::from(pkg_dir), pkg_name);
         fix_cargo_metadata(pkg_dir);
+
+        // Restore preserved version (openapi-generator resets it to spec version)
+        if let Some(ref version) = existing_version {
+            let cargo_toml_path = Path::new(pkg_dir).join("Cargo.toml");
+            let contents = read_file(&cargo_toml_path);
+            let updated = contents
+                .lines()
+                .map(|line| {
+                    if line.starts_with("version = ") {
+                        format!("version = \"{version}\"")
+                    } else {
+                        line.to_string()
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            write_file(&cargo_toml_path, &updated);
+        }
+
         fix_generated_dependencies(pkg_dir);
         fix_workspace_dependencies(pkg_dir);
         fix_workspace_lints(pkg_dir);

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -479,6 +479,22 @@ fn main() {
         let pkg_name = &format!("{PKG_NAME_PREFIX}_{}", service.replace("-", "_"));
         let pkg_dir = &format!("{OUTPUT_DIR}/{pkg_name}");
 
+        // Preserve existing version from Cargo.toml before regeneration
+        let existing_version = {
+            let cargo_toml_path = Path::new(pkg_dir).join("Cargo.toml");
+            if cargo_toml_path.exists() {
+                let contents = read_file(&cargo_toml_path);
+                contents
+                    .lines()
+                    .find(|l| l.starts_with("version = "))
+                    .and_then(|l| l.strip_prefix("version = \""))
+                    .and_then(|l| l.strip_suffix('"'))
+                    .map(|v| v.to_string())
+            } else {
+                None
+            }
+        };
+
         // Initialize package directory (preserve hand-written tests/)
         let tests_dir = Path::new(pkg_dir).join("tests");
         let tests_backup = Path::new(pkg_dir).with_file_name(format!("{pkg_name}_tests_backup"));
@@ -533,6 +549,25 @@ fn main() {
 
         process_directory(&PathBuf::from(pkg_dir), pkg_name);
         fix_cargo_metadata(pkg_dir);
+
+        // Restore preserved version (openapi-generator resets it)
+        if let Some(ref version) = existing_version {
+            let cargo_toml_path = Path::new(pkg_dir).join("Cargo.toml");
+            let contents = read_file(&cargo_toml_path);
+            let updated = contents
+                .lines()
+                .map(|line| {
+                    if line.starts_with("version = ") {
+                        format!("version = \"{version}\"")
+                    } else {
+                        line.to_string()
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            write_file(&cargo_toml_path, &updated);
+        }
+
         fix_generated_dependencies(pkg_dir);
         fix_workspace_dependencies(pkg_dir);
         fix_workspace_lints(pkg_dir);

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -555,18 +555,14 @@ fn main() {
         if let Some(ref version) = existing_version {
             let cargo_toml_path = Path::new(pkg_dir).join("Cargo.toml");
             let contents = read_file(&cargo_toml_path);
-            let updated = contents
+            let generated_version = contents
                 .lines()
-                .map(|line| {
-                    if line.starts_with("version = ") {
-                        format!("version = \"{version}\"")
-                    } else {
-                        line.to_string()
-                    }
-                })
-                .collect::<Vec<_>>()
-                .join("\n");
-            write_file(&cargo_toml_path, &updated);
+                .find(|l| l.starts_with("version = "))
+                .map(|l| l.to_string());
+            if let Some(old) = generated_version {
+                let updated = contents.replace(&old, &format!("version = \"{version}\""));
+                write_file(&cargo_toml_path, &updated);
+            }
         }
 
         fix_generated_dependencies(pkg_dir);

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -479,22 +479,6 @@ fn main() {
         let pkg_name = &format!("{PKG_NAME_PREFIX}_{}", service.replace("-", "_"));
         let pkg_dir = &format!("{OUTPUT_DIR}/{pkg_name}");
 
-        // Preserve existing version from Cargo.toml before regeneration
-        let existing_version = {
-            let cargo_toml_path = Path::new(pkg_dir).join("Cargo.toml");
-            if cargo_toml_path.exists() {
-                let contents = read_file(&cargo_toml_path);
-                contents
-                    .lines()
-                    .find(|l| l.starts_with("version = "))
-                    .and_then(|l| l.strip_prefix("version = \""))
-                    .and_then(|l| l.strip_suffix('"'))
-                    .map(|v| v.to_string())
-            } else {
-                None
-            }
-        };
-
         // Initialize package directory (preserve hand-written tests/)
         let tests_dir = Path::new(pkg_dir).join("tests");
         let tests_backup = Path::new(pkg_dir).with_file_name(format!("{pkg_name}_tests_backup"));
@@ -549,25 +533,6 @@ fn main() {
 
         process_directory(&PathBuf::from(pkg_dir), pkg_name);
         fix_cargo_metadata(pkg_dir);
-
-        // Restore preserved version (openapi-generator resets it)
-        if let Some(ref version) = existing_version {
-            let cargo_toml_path = Path::new(pkg_dir).join("Cargo.toml");
-            let contents = read_file(&cargo_toml_path);
-            let updated = contents
-                .lines()
-                .map(|line| {
-                    if line.starts_with("version = ") {
-                        format!("version = \"{version}\"")
-                    } else {
-                        line.to_string()
-                    }
-                })
-                .collect::<Vec<_>>()
-                .join("\n");
-            write_file(&cargo_toml_path, &updated);
-        }
-
         fix_generated_dependencies(pkg_dir);
         fix_workspace_dependencies(pkg_dir);
         fix_workspace_lints(pkg_dir);


### PR DESCRIPTION
## Summary
- Bump all sub-crate versions for crates.io publish compatibility
- Point `line-openapi` submodule to official `line/line-openapi` (was `nanato12/line-openapi` fork)
- Generator preserves existing sub-crate versions across regeneration (no longer tied to OpenAPI spec `info.version`)
- Auto-publish all sub-crates on release via `make publish`
- Remove manual `publish-line-module.yml` workflow (no longer needed)
- Update CLAUDE.md to reflect the above changes

| Crate | Old | New |
|---|---|---|
| line_channel_access_token | 0.0.2 | 1.0.0 |
| line_insight | 0.0.2 | 1.0.0 |
| line_liff | 1.1.0 | 1.2.0 |
| line_manage_audience | 0.0.2 | 1.0.0 |
| line_messaging_api | 0.0.4 | 1.0.0 |
| line_module | 0.0.2 | 1.0.0 |
| line_module_attach | 0.0.2 | 1.0.0 |
| line_shop | 0.0.1 | 1.0.0 |
| line_webhook | 1.0.2 | 1.0.3 |

## Test plan
- [ ] `cargo check --workspace` passes
- [ ] All CI checks green
- [ ] `make generate` preserves bumped versions (check-generate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)