### PR TITLE
Add Python linting infrastructure with ruff and mypy

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,10 +36,7 @@ jobs:
         run: ruff check .
 
       - name: Run ruff format check
-        run: ruff format --check --diff . || true
-      
-      - name: Show full diff
-        run: ruff format --diff .
+        run: ruff format --check .
 
       - name: Run mypy
         run: mypy .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,7 +36,10 @@ jobs:
         run: ruff check .
 
       - name: Run ruff format check
-        run: ruff format --check .
+        run: ruff format --check --diff . || true
+      
+      - name: Show full diff
+        run: ruff format --diff .
 
       - name: Run mypy
         run: mypy .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,42 @@
+name: Python Lint
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/lint.yml
+      - "**.py"
+      - "pyproject.toml"
+      - "requirements-dev.txt"
+  push:
+    branches:
+      - develop
+      - main
+    paths:
+      - .github/workflows/lint.yml
+      - "**.py"
+      - "pyproject.toml"
+      - "requirements-dev.txt"
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Run ruff check
+        run: ruff check .
+
+      - name: Run ruff format check
+        run: ruff format --check .
+
+      - name: Run mypy
+        run: mypy .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,7 +36,7 @@ jobs:
         run: ruff check .
 
       - name: Run ruff format check
-        run: ruff format --check .
+        run: ruff format --check --diff .
 
       - name: Run mypy
         run: mypy .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,7 +36,7 @@ jobs:
         run: ruff check .
 
       - name: Run ruff format check
-        run: ruff format --check --diff .
+        run: ruff format --check .
 
       - name: Run mypy
         run: mypy .

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,11 @@ Cargo.lock
 /tools/openapi-generator-cli-*.jar
 /generator/target/
 /generator/dependency-reduced-pom.xml
+
+# python
+venv/
+__pycache__/
+*.py[cod]
+*$py.class
+.mypy_cache/
+.ruff_cache/

--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,14 @@ publish:
 .PHONY: generate
 generate:
 	python3 generate-code.py
+
+.PHONY: lint
+lint:
+	ruff check .
+	ruff format --check .
+	mypy .
+
+.PHONY: fmt
+fmt:
+	ruff format .
+	ruff check --fix .

--- a/generate-code.py
+++ b/generate-code.py
@@ -57,7 +57,7 @@ def read_version(cargo_toml: str) -> str:
     return "0.0.1"
 
 
-def build_generator():
+def build_generator() -> None:
     """Build the Maven generator plugin."""
     print("Building generator plugin...")
     subprocess.run(
@@ -76,7 +76,7 @@ def build_generator():
         sys.exit(1)
 
 
-def generate_service(spec_file: str, output_dir: str, package_name: str):
+def generate_service(spec_file: str, output_dir: str, package_name: str) -> None:
     """Generate code for a single service."""
     spec_path = os.path.join(ROOT, "line-openapi", spec_file)
     out_path = os.path.join(ROOT, output_dir)
@@ -153,7 +153,7 @@ def generate_service(spec_file: str, output_dir: str, package_name: str):
         shutil.rmtree(oag_dir)
 
 
-def _remove_type_field(file_path: str, type_comment: str):
+def _remove_type_field(file_path: str, type_comment: str) -> None:
     """Remove the r#type / type discriminator field from a generated model file.
 
     Matches old post-processor behavior: removes serde rename, field declaration,
@@ -198,7 +198,7 @@ def _remove_type_field(file_path: str, type_comment: str):
             f.write(contents)
 
 
-def _fix_blank_line_before_execute(api_dir: str):
+def _fix_blank_line_before_execute(api_dir: str) -> None:
     """Ensure blank line before req.execute() in API files (matching old output)."""
     if not os.path.isdir(api_dir):
         return
@@ -219,7 +219,7 @@ def _fix_blank_line_before_execute(api_dir: str):
                 f.write(modified)
 
 
-def post_process_webhook():
+def post_process_webhook() -> None:
     """Remove type field from webhook event/source/message_content models."""
     models_dir = os.path.join(ROOT, "core", "line_webhook", "src", "models")
     if not os.path.isdir(models_dir):
@@ -236,7 +236,7 @@ def post_process_webhook():
             _remove_type_field(fpath, "Type")
 
 
-def post_process_messaging_api():
+def post_process_messaging_api() -> None:
     """Apply messaging_api-specific fixes matching old post-processor behavior."""
     pkg_dir = os.path.join(ROOT, "core", "line_messaging_api")
     models_dir = os.path.join(pkg_dir, "src", "models")
@@ -261,7 +261,7 @@ def post_process_messaging_api():
                 _remove_type_field(fpath, "Type of message")
 
 
-def post_process_manage_audience():
+def post_process_manage_audience() -> None:
     """Apply manage_audience-specific fixes matching old post-processor behavior."""
     pkg_dir = os.path.join(ROOT, "core", "line_manage_audience")
     models_dir = os.path.join(pkg_dir, "src", "models")
@@ -287,7 +287,7 @@ def post_process_manage_audience():
                 f.write(modified)
 
 
-def copy_hand_written_sources():
+def copy_hand_written_sources() -> None:
     """Copy hand-written source files over generated ones."""
     print("Copying hand-written sources...")
     for source in HAND_WRITTEN_SOURCES:
@@ -298,7 +298,7 @@ def copy_hand_written_sources():
             print(f"  {source}")
 
 
-def cargo_fix():
+def cargo_fix() -> None:
     """Run cargo fix to auto-rename unused variables."""
     print("Running cargo fix...")
     subprocess.run(
@@ -308,7 +308,7 @@ def cargo_fix():
     )
 
 
-def format_code():
+def format_code() -> None:
     """Run cargo fmt on the workspace."""
     print("Running cargo fmt...")
     subprocess.run(
@@ -318,7 +318,7 @@ def format_code():
     )
 
 
-def download_cli():
+def download_cli() -> None:
     """Download the OpenAPI Generator CLI JAR if not present."""
     if os.path.exists(CLI_JAR):
         return
@@ -328,7 +328,7 @@ def download_cli():
     print(f"  Saved to {CLI_JAR}")
 
 
-def main():
+def main() -> None:
     download_cli()
 
     build_generator()

--- a/generate-code.py
+++ b/generate-code.py
@@ -183,8 +183,9 @@ def _remove_type_field(file_path: str, type_comment: str):
     # Remove type comment (e.g., "/// Type of the event")
     if type_comment:
         contents = re.sub(
-            rf'\s*/// {re.escape(type_comment)}\n',
-            "\n", contents,
+            rf"\s*/// {re.escape(type_comment)}\n",
+            "\n",
+            contents,
         )
 
     if contents != original:
@@ -204,8 +205,8 @@ def _fix_blank_line_before_execute(api_dir: str):
             contents = f.read()
         # Add blank line before req.execute() if not already present
         modified = re.sub(
-            r'([^\n])\n(\s*req\.execute\()',
-            r'\1\n\n\2',
+            r"([^\n])\n(\s*req\.execute\()",
+            r"\1\n\n\2",
             contents,
         )
         if modified != contents:

--- a/generate-code.py
+++ b/generate-code.py
@@ -23,7 +23,11 @@ GENERATOR_JAR = os.path.join(
 
 # Mapping: (spec file, output directory, package name)
 SERVICES = [
-    ("channel-access-token.yml", "core/line_channel_access_token", "line_channel_access_token"),
+    (
+        "channel-access-token.yml",
+        "core/line_channel_access_token",
+        "line_channel_access_token",
+    ),
     ("insight.yml", "core/line_insight", "line_insight"),
     ("liff.yml", "core/line_liff", "line_liff"),
     ("manage-audience.yml", "core/line_manage_audience", "line_manage_audience"),
@@ -59,8 +63,14 @@ def build_generator():
     """Build the Maven generator plugin."""
     print("Building generator plugin...")
     subprocess.run(
-        ["mvn", "-f", os.path.join(ROOT, "generator", "pom.xml"),
-         "package", "-q", "-DskipTests"],
+        [
+            "mvn",
+            "-f",
+            os.path.join(ROOT, "generator", "pom.xml"),
+            "package",
+            "-q",
+            "-DskipTests",
+        ],
         check=True,
     )
     if not os.path.exists(GENERATOR_JAR):
@@ -148,7 +158,8 @@ def _remove_type_field(file_path: str, type_comment: str):
     """
     if not os.path.exists(file_path):
         return
-    contents = open(file_path).read()
+    with open(file_path) as f:
+        contents = f.read()
     original = contents
 
     # Remove serde attribute for type field (with or without indentation)
@@ -227,7 +238,8 @@ def post_process_messaging_api():
     # Add #[allow(non_camel_case_types)] to AreaDemographic
     area_demo = os.path.join(models_dir, "area_demographic.rs")
     if os.path.exists(area_demo):
-        contents = open(area_demo).read()
+        with open(area_demo) as f:
+            contents = f.read()
         contents = contents.replace(
             "pub enum AreaDemographic",
             "#[allow(non_camel_case_types)]\npub enum AreaDemographic",
@@ -253,7 +265,8 @@ def post_process_manage_audience():
         fpath = os.path.join(models_dir, fname)
         if not fname.endswith(".rs"):
             continue
-        contents = open(fpath).read()
+        with open(fpath) as f:
+            contents = f.read()
         modified = contents
         modified = modified.replace(
             "status: Option<AudienceGroupStatus>",

--- a/generate-code.py
+++ b/generate-code.py
@@ -17,9 +17,7 @@ ROOT = os.path.dirname(os.path.abspath(__file__))
 CLI_VERSION = "7.20.0"
 CLI_JAR = os.path.join(ROOT, "tools", f"openapi-generator-cli-{CLI_VERSION}.jar")
 CLI_URL = f"https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/{CLI_VERSION}/openapi-generator-cli-{CLI_VERSION}.jar"
-GENERATOR_JAR = os.path.join(
-    ROOT, "generator", "target", "line-bot-sdk-rust-generator-1.0.0.jar"
-)
+GENERATOR_JAR = os.path.join(ROOT, "generator", "target", "line-bot-sdk-rust-generator-1.0.0.jar")
 
 # Mapping: (spec file, output directory, package name)
 SERVICES = [
@@ -118,13 +116,19 @@ def generate_service(spec_file: str, output_dir: str, package_name: str):
     # Run OpenAPI Generator
     classpath = f"{CLI_JAR}:{GENERATOR_JAR}"
     cmd = [
-        "java", "-cp", classpath,
+        "java",
+        "-cp",
+        classpath,
         "org.openapitools.codegen.OpenAPIGenerator",
         "generate",
-        "-g", "line-bot-sdk-rust-generator",
-        "-e", "pebble",
-        "-i", spec_path,
-        "-o", out_path,
+        "-g",
+        "line-bot-sdk-rust-generator",
+        "-e",
+        "pebble",
+        "-i",
+        spec_path,
+        "-o",
+        out_path,
         "--additional-properties",
         f"packageName={package_name},packageVersion={version}",
     ]

--- a/generate-code.py
+++ b/generate-code.py
@@ -163,21 +163,22 @@ def _remove_type_field(file_path: str, type_comment: str):
     original = contents
 
     # Remove serde attribute for type field (with or without indentation)
-    contents = re.sub(r'\s*#\[serde\(rename = "type"\)\]\n', "\n", contents)
+    contents = re.sub(r"\s*#\[serde\(rename = \"type\"\)\]\n", "\n", contents)
     # Remove serde attribute for optional type field
     contents = re.sub(
-        r'\s*#\[serde\(rename = "type", skip_serializing_if = "Option::is_none"\)\]\n',
-        "\n", contents,
+        r"\s*#\[serde\(rename = \"type\", skip_serializing_if = \"Option::is_none\"\)\]\n",
+        "\n",
+        contents,
     )
     # Remove type field declaration (required: pub r#type: String,)
-    contents = re.sub(r'\s*pub r#type: String,\n', "\n", contents)
+    contents = re.sub(r"\s*pub r#type: String,\n", "\n", contents)
     # Remove type field declaration (optional: pub r#type: Option<String>,)
-    contents = re.sub(r'\s*pub r#type: Option<String>,\n', "\n", contents)
+    contents = re.sub(r"\s*pub r#type: Option<String>,\n", "\n", contents)
     # Remove type field in constructor body (r#type, or r#type: None,)
-    contents = re.sub(r'\s*r#type,\n', "\n", contents)
-    contents = re.sub(r'\s*r#type: None,\n', "\n", contents)
+    contents = re.sub(r"\s*r#type,\n", "\n", contents)
+    contents = re.sub(r"\s*r#type: None,\n", "\n", contents)
     # Remove type as first constructor param (when followed by more params)
-    contents = re.sub(r'new\(r#type: String, ', "new(", contents)
+    contents = re.sub(r"new\(r#type: String, ", "new(", contents)
     # NOTE: Do NOT remove r#type when it's the only param.
     # cargo fix will rename it to _type, matching old behavior.
     # Remove type comment (e.g., "/// Type of the event")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.ruff]
-line-length = 88
+line-length = 100
 show-fixes = true
 
 [tool.ruff.format]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[tool.ruff]
+line-length = 88
+show-fixes = true
+
+[tool.ruff.format]
+docstring-code-format = false
+line-ending = "lf"
+
+[tool.ruff.lint]
+select = ["E", "F", "I"]
+ignore = []
+fixable = ["ALL"]
+unfixable = []
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["E402"]
+
+[tool.mypy]
+explicit_package_bases = true
+warn_return_any = true
+no_implicit_optional = true
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+ignore_missing_imports = true
+follow_imports = 'skip'
+exclude = ['^venv/*', '^tools/*']

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+ruff==0.15.2
+mypy==1.19.1
+mypy-extensions==1.1.0


### PR DESCRIPTION
## Summary

This PR introduces Python code quality tools and automated linting infrastructure for the repository.

## Changes

- **pyproject.toml**: Configuration for ruff and mypy
  - Ruff: line length 88, E/F/I rule sets enabled
  - Mypy: strict type checking with sensible defaults
- **requirements-dev.txt**: Development dependencies (ruff, mypy, mypy-extensions)
- **GitHub Actions workflow**: Automated lint checks on PR and push
  - Runs `ruff check`, `ruff format --check`, and `mypy`
  - Triggers on Python file changes
- **Makefile targets**:
  - `make lint`: Run all lint checks
  - `make fmt`: Auto-format and fix code
- **.gitignore**: Ignore Python artifacts (venv, cache, etc.)

## Benefits

- **Code quality**: Enforces consistent formatting and catches common errors
- **CI integration**: Automated checks prevent merging non-compliant code
- **Developer experience**: Quick local checks with `make lint` and `make fmt`
- **Future-proof**: Foundation for scaling Python tooling in the project

## Testing

CI workflow will run automatically on this PR. Expected to pass once any existing Python code is formatted.