### PR TITLE
Add comprehensive axum webhook example with modular handlers

### DIFF
--- a/examples/axum_example/src/handler.rs
+++ b/examples/axum_example/src/handler.rs
@@ -1,0 +1,34 @@
+//! Top-level event dispatcher.
+//!
+//! Routes each webhook event type to its corresponding handler module.
+
+use line_bot_sdk_rust::{client::LINE, line_webhook::models::Event};
+
+use crate::handlers;
+
+/// Dispatches a webhook event to the appropriate handler.
+///
+/// Matches on the event type and delegates to the corresponding handler module.
+/// Any errors returned by handlers are logged to stderr.
+pub async fn handle_event(line: &LINE, event: Event) {
+    let result = match event {
+        Event::MessageEvent(e) => handlers::message::handle(line, e).await,
+        Event::FollowEvent(e) => handlers::follow::handle(line, e).await,
+        Event::UnfollowEvent(e) => handlers::unfollow::handle(e),
+        Event::JoinEvent(e) => handlers::join::handle(line, e).await,
+        Event::LeaveEvent(e) => handlers::leave::handle(e),
+        Event::MemberJoinedEvent(e) => handlers::member_joined::handle(line, e).await,
+        Event::MemberLeftEvent(e) => handlers::member_left::handle(e),
+        Event::PostbackEvent(e) => handlers::postback::handle(line, e).await,
+        Event::UnsendEvent(e) => handlers::unsend::handle(e),
+        Event::BeaconEvent(e) => handlers::beacon::handle(line, e).await,
+        _ => {
+            println!("[unhandled event]");
+            Ok(())
+        }
+    };
+
+    if let Err(e) = result {
+        eprintln!("[error] {e}");
+    }
+}

--- a/examples/axum_example/src/handlers/beacon.rs
+++ b/examples/axum_example/src/handlers/beacon.rs
@@ -1,0 +1,36 @@
+//! Beacon event handler.
+//!
+//! Triggered when a user enters, leaves, or stays in range of a LINE Beacon.
+
+use line_bot_sdk_rust::{
+    client::LINE,
+    line_messaging_api::{
+        apis::MessagingApiApi,
+        models::{Message, ReplyMessageRequest, TextMessage},
+    },
+    line_webhook::models::BeaconEvent,
+};
+
+/// Replies with the detected beacon hardware ID.
+pub async fn handle(line: &LINE, event: BeaconEvent) -> Result<(), String> {
+    println!(
+        "[beacon] hwid={} type={:?}",
+        event.beacon.hwid, event.beacon.r#type
+    );
+
+    let req = ReplyMessageRequest {
+        reply_token: event.reply_token,
+        messages: vec![Message::TextMessage(TextMessage::new(format!(
+            "Beacon detected! (hwid: {})",
+            event.beacon.hwid
+        )))],
+        notification_disabled: Some(false),
+    };
+
+    line.messaging_api_client
+        .reply_message(req)
+        .await
+        .map_err(|e| format!("reply_message failed: {e}"))?;
+
+    Ok(())
+}

--- a/examples/axum_example/src/handlers/commands/botinfo.rs
+++ b/examples/axum_example/src/handlers/commands/botinfo.rs
@@ -1,0 +1,32 @@
+//! `/botinfo` command handler.
+//!
+//! Fetches and displays the bot's own profile information.
+
+use line_bot_sdk_rust::{
+    client::LINE,
+    line_messaging_api::{
+        apis::MessagingApiApi,
+        models::{Message, ReplyMessageRequest, TextMessage},
+    },
+};
+
+/// Retrieves the bot's info via the Messaging API and replies with a debug dump.
+pub async fn handle(line: &LINE, reply_token: String) -> Result<(), String> {
+    let text = match line.messaging_api_client.get_bot_info().await {
+        Ok(info) => format!("{info:#?}"),
+        Err(e) => format!("Failed to get bot info: {e}"),
+    };
+
+    let req = ReplyMessageRequest {
+        reply_token,
+        messages: vec![Message::TextMessage(TextMessage::new(text))],
+        notification_disabled: Some(false),
+    };
+
+    line.messaging_api_client
+        .reply_message(req)
+        .await
+        .map_err(|e| format!("reply_message failed: {e}"))?;
+
+    Ok(())
+}

--- a/examples/axum_example/src/handlers/commands/flex.rs
+++ b/examples/axum_example/src/handlers/commands/flex.rs
@@ -1,0 +1,52 @@
+//! `/flex` command handler.
+//!
+//! Sends a Flex Message sample built programmatically using the SDK's model types.
+
+use line_bot_sdk_rust::{
+    client::LINE,
+    line_messaging_api::{
+        apis::MessagingApiApi,
+        models::{
+            flex_box::Layout, FlexBox, FlexBubble, FlexCarousel, FlexComponent, FlexContainer,
+            FlexMessage, FlexText, Message, ReplyMessageRequest,
+        },
+    },
+};
+
+/// Builds a FlexCarousel with two identical bubbles and sends it as a reply.
+pub async fn handle(line: &LINE, reply_token: String) -> Result<(), String> {
+    // Build a FlexContainer programmatically using the SDK's model constructors.
+    let bubble = FlexBubble {
+        body: Some(Box::new(FlexBox::new(
+            Layout::Vertical,
+            vec![FlexComponent::FlexText(FlexText {
+                text: Some("hello, world".to_string()),
+                ..Default::default()
+            })],
+        ))),
+        ..FlexBubble::new()
+    };
+
+    let contents = FlexContainer::FlexCarousel(FlexCarousel::new(vec![bubble.clone(), bubble]));
+
+    println!(
+        "[flex] payload: {}",
+        serde_json::to_string_pretty(&contents).unwrap_or_default()
+    );
+
+    let req = ReplyMessageRequest {
+        reply_token,
+        messages: vec![Message::FlexMessage(FlexMessage::new(
+            "Flex Message".to_string(),
+            contents,
+        ))],
+        notification_disabled: Some(false),
+    };
+
+    line.messaging_api_client
+        .reply_message(req)
+        .await
+        .map_err(|e| format!("reply_message failed: {e}"))?;
+
+    Ok(())
+}

--- a/examples/axum_example/src/handlers/commands/ginfo.rs
+++ b/examples/axum_example/src/handlers/commands/ginfo.rs
@@ -1,0 +1,61 @@
+//! `/ginfo` command handler.
+//!
+//! Fetches and displays group summary and member count.
+//! Only works when sent inside a group chat.
+
+use line_bot_sdk_rust::{
+    client::LINE,
+    line_messaging_api::{
+        apis::MessagingApiApi,
+        models::{Message, ReplyMessageRequest, TextMessage},
+    },
+    line_webhook::models::Source,
+};
+
+/// Retrieves the group summary and member count, then replies with both.
+/// Returns a message explaining this command is group-only if used elsewhere.
+pub async fn handle(
+    line: &LINE,
+    reply_token: String,
+    source: &Option<Box<Source>>,
+) -> Result<(), String> {
+    let group_id = match source {
+        Some(s) => match s.as_ref() {
+            Source::GroupSource(g) => Some(g.group_id.clone()),
+            _ => None,
+        },
+        None => None,
+    };
+
+    let text = match group_id {
+        Some(gid) => {
+            let mut parts = Vec::new();
+
+            match line.messaging_api_client.get_group_summary(&gid).await {
+                Ok(summary) => parts.push(format!("{summary:#?}")),
+                Err(e) => parts.push(format!("get_group_summary error: {e}")),
+            }
+
+            match line.messaging_api_client.get_group_member_count(&gid).await {
+                Ok(count) => parts.push(format!("{count:#?}")),
+                Err(e) => parts.push(format!("get_group_member_count error: {e}")),
+            }
+
+            parts.join("\n\n")
+        }
+        None => "This command can only be used in a group.".to_string(),
+    };
+
+    let req = ReplyMessageRequest {
+        reply_token,
+        messages: vec![Message::TextMessage(TextMessage::new(text))],
+        notification_disabled: Some(false),
+    };
+
+    line.messaging_api_client
+        .reply_message(req)
+        .await
+        .map_err(|e| format!("reply_message failed: {e}"))?;
+
+    Ok(())
+}

--- a/examples/axum_example/src/handlers/commands/help.rs
+++ b/examples/axum_example/src/handlers/commands/help.rs
@@ -1,0 +1,37 @@
+//! `/help` command handler.
+//!
+//! Lists all available slash commands.
+
+use line_bot_sdk_rust::{
+    client::LINE,
+    line_messaging_api::{
+        apis::MessagingApiApi,
+        models::{Message, ReplyMessageRequest, TextMessage},
+    },
+};
+
+/// Replies with a list of all supported commands and their descriptions.
+pub async fn handle(line: &LINE, reply_token: String) -> Result<(), String> {
+    let text = "\
+Available commands:
+/help - Show this help message
+/profile - Show your profile info
+/botinfo - Show bot info
+/ginfo - Show group info (group only)
+/flex - Send a Flex Message sample
+/leave - Leave the current group/room (group only)"
+        .to_string();
+
+    let req = ReplyMessageRequest {
+        reply_token,
+        messages: vec![Message::TextMessage(TextMessage::new(text))],
+        notification_disabled: Some(false),
+    };
+
+    line.messaging_api_client
+        .reply_message(req)
+        .await
+        .map_err(|e| format!("reply_message failed: {e}"))?;
+
+    Ok(())
+}

--- a/examples/axum_example/src/handlers/commands/leave.rs
+++ b/examples/axum_example/src/handlers/commands/leave.rs
@@ -1,0 +1,60 @@
+//! `/leave` command handler.
+//!
+//! Makes the bot leave the current group or room after sending a farewell message.
+
+use line_bot_sdk_rust::{
+    client::LINE,
+    line_messaging_api::{
+        apis::MessagingApiApi,
+        models::{Message, ReplyMessageRequest, TextMessage},
+    },
+    line_webhook::models::Source,
+};
+
+/// Sends a goodbye message, then calls leave_group or leave_room depending on
+/// the event source type. Does nothing in 1-on-1 chats.
+pub async fn handle(
+    line: &LINE,
+    reply_token: String,
+    source: &Option<Box<Source>>,
+) -> Result<(), String> {
+    let req = ReplyMessageRequest {
+        reply_token,
+        messages: vec![Message::TextMessage(TextMessage::new(
+            "Bye everyone! See you later!".to_string(),
+        ))],
+        notification_disabled: Some(false),
+    };
+
+    line.messaging_api_client
+        .reply_message(req)
+        .await
+        .map_err(|e| format!("reply_message failed: {e}"))?;
+
+    match source {
+        Some(s) => match s.as_ref() {
+            Source::GroupSource(g) => {
+                println!("[command/leave] Leaving group {}", g.group_id);
+                line.messaging_api_client
+                    .leave_group(&g.group_id)
+                    .await
+                    .map_err(|e| format!("leave_group failed: {e}"))?;
+            }
+            Source::RoomSource(r) => {
+                println!("[command/leave] Leaving room {}", r.room_id);
+                line.messaging_api_client
+                    .leave_room(&r.room_id)
+                    .await
+                    .map_err(|e| format!("leave_room failed: {e}"))?;
+            }
+            _ => {
+                println!("[command/leave] Not in a group or room, ignoring");
+            }
+        },
+        None => {
+            println!("[command/leave] No source, ignoring");
+        }
+    }
+
+    Ok(())
+}

--- a/examples/axum_example/src/handlers/commands/mod.rs
+++ b/examples/axum_example/src/handlers/commands/mod.rs
@@ -1,0 +1,10 @@
+//! Slash command handlers.
+//!
+//! Each submodule handles a specific `/command` sent as a text message.
+
+pub mod botinfo;
+pub mod flex;
+pub mod ginfo;
+pub mod help;
+pub mod leave;
+pub mod profile;

--- a/examples/axum_example/src/handlers/commands/profile.rs
+++ b/examples/axum_example/src/handlers/commands/profile.rs
@@ -1,0 +1,50 @@
+//! `/profile` command handler.
+//!
+//! Fetches and displays the sender's LINE profile information.
+
+use line_bot_sdk_rust::{
+    client::LINE,
+    line_messaging_api::{
+        apis::MessagingApiApi,
+        models::{Message, ReplyMessageRequest, TextMessage},
+    },
+    line_webhook::models::Source,
+};
+
+/// Looks up the sender's user ID from the event source and replies with their profile.
+pub async fn handle(
+    line: &LINE,
+    reply_token: String,
+    source: &Option<Box<Source>>,
+) -> Result<(), String> {
+    let user_id = match source {
+        Some(s) => match s.as_ref() {
+            Source::UserSource(u) => u.user_id.clone(),
+            Source::GroupSource(g) => g.user_id.clone(),
+            Source::RoomSource(r) => r.user_id.clone(),
+            _ => None,
+        },
+        None => None,
+    };
+
+    let text = match user_id {
+        Some(uid) => match line.messaging_api_client.get_profile(&uid).await {
+            Ok(profile) => format!("{profile:#?}"),
+            Err(e) => format!("Failed to get profile: {e}"),
+        },
+        None => "Could not determine your user ID.".to_string(),
+    };
+
+    let req = ReplyMessageRequest {
+        reply_token,
+        messages: vec![Message::TextMessage(TextMessage::new(text))],
+        notification_disabled: Some(false),
+    };
+
+    line.messaging_api_client
+        .reply_message(req)
+        .await
+        .map_err(|e| format!("reply_message failed: {e}"))?;
+
+    Ok(())
+}

--- a/examples/axum_example/src/handlers/follow.rs
+++ b/examples/axum_example/src/handlers/follow.rs
@@ -1,0 +1,32 @@
+//! Follow event handler.
+//!
+//! Triggered when a user adds the bot as a friend.
+
+use line_bot_sdk_rust::{
+    client::LINE,
+    line_messaging_api::{
+        apis::MessagingApiApi,
+        models::{Message, ReplyMessageRequest, TextMessage},
+    },
+    line_webhook::models::FollowEvent,
+};
+
+/// Sends a greeting message when a user adds the bot as a friend.
+pub async fn handle(line: &LINE, event: FollowEvent) -> Result<(), String> {
+    println!("[follow] New friend added!");
+
+    let req = ReplyMessageRequest {
+        reply_token: event.reply_token,
+        messages: vec![Message::TextMessage(TextMessage::new(
+            "Thanks for adding me as a friend! I'm an echo bot built with line-bot-sdk-rust. Send me a message and I'll echo it back!".to_string(),
+        ))],
+        notification_disabled: Some(false),
+    };
+
+    line.messaging_api_client
+        .reply_message(req)
+        .await
+        .map_err(|e| format!("reply_message failed: {e}"))?;
+
+    Ok(())
+}

--- a/examples/axum_example/src/handlers/join.rs
+++ b/examples/axum_example/src/handlers/join.rs
@@ -1,0 +1,32 @@
+//! Join event handler.
+//!
+//! Triggered when the bot is invited to a group or multi-person chat room.
+
+use line_bot_sdk_rust::{
+    client::LINE,
+    line_messaging_api::{
+        apis::MessagingApiApi,
+        models::{Message, ReplyMessageRequest, TextMessage},
+    },
+    line_webhook::models::JoinEvent,
+};
+
+/// Sends a greeting when the bot joins a group or room.
+pub async fn handle(line: &LINE, event: JoinEvent) -> Result<(), String> {
+    println!("[join] Bot joined a group/room!");
+
+    let req = ReplyMessageRequest {
+        reply_token: event.reply_token,
+        messages: vec![Message::TextMessage(TextMessage::new(
+            "Hello everyone! Thanks for inviting me! I'm an echo bot -- send me a text and I'll repeat it.".to_string(),
+        ))],
+        notification_disabled: Some(false),
+    };
+
+    line.messaging_api_client
+        .reply_message(req)
+        .await
+        .map_err(|e| format!("reply_message failed: {e}"))?;
+
+    Ok(())
+}

--- a/examples/axum_example/src/handlers/leave.rs
+++ b/examples/axum_example/src/handlers/leave.rs
@@ -1,0 +1,13 @@
+//! Leave event handler.
+//!
+//! Triggered when the bot is removed from a group or room. No reply is possible.
+
+use line_bot_sdk_rust::line_webhook::models::LeaveEvent;
+
+pub fn handle(event: LeaveEvent) -> Result<(), String> {
+    println!(
+        "[leave] Bot was removed from a group/room (event_id: {})",
+        event.webhook_event_id
+    );
+    Ok(())
+}

--- a/examples/axum_example/src/handlers/member_joined.rs
+++ b/examples/axum_example/src/handlers/member_joined.rs
@@ -1,0 +1,37 @@
+//! Member joined event handler.
+//!
+//! Triggered when new members join a group that the bot is in.
+
+use line_bot_sdk_rust::{
+    client::LINE,
+    line_messaging_api::{
+        apis::MessagingApiApi,
+        models::{Message, ReplyMessageRequest, TextMessage},
+    },
+    line_webhook::models::MemberJoinedEvent,
+};
+
+/// Sends a welcome message for new group members.
+pub async fn handle(line: &LINE, event: MemberJoinedEvent) -> Result<(), String> {
+    let count = event.joined.members.len();
+    println!("[member_joined] {count} member(s) joined the group");
+
+    let text = if count == 1 {
+        "Welcome to the group! Nice to meet you!".to_string()
+    } else {
+        format!("Welcome to the group, {count} new members! Nice to meet you all!")
+    };
+
+    let req = ReplyMessageRequest {
+        reply_token: event.reply_token,
+        messages: vec![Message::TextMessage(TextMessage::new(text))],
+        notification_disabled: Some(false),
+    };
+
+    line.messaging_api_client
+        .reply_message(req)
+        .await
+        .map_err(|e| format!("reply_message failed: {e}"))?;
+
+    Ok(())
+}

--- a/examples/axum_example/src/handlers/member_left.rs
+++ b/examples/axum_example/src/handlers/member_left.rs
@@ -1,0 +1,11 @@
+//! Member left event handler.
+//!
+//! Triggered when members leave a group that the bot is in. No reply is sent.
+
+use line_bot_sdk_rust::line_webhook::models::MemberLeftEvent;
+
+pub fn handle(event: MemberLeftEvent) -> Result<(), String> {
+    let count = event.left.members.len();
+    println!("[member_left] {count} member(s) left the group");
+    Ok(())
+}

--- a/examples/axum_example/src/handlers/message.rs
+++ b/examples/axum_example/src/handlers/message.rs
@@ -1,0 +1,201 @@
+//! Message event handler.
+//!
+//! Handles all incoming message types (text, sticker, location, image, video,
+//! audio, file) and dispatches slash commands to the commands module.
+
+use line_bot_sdk_rust::{
+    client::LINE,
+    line_messaging_api::{
+        apis::MessagingApiApi,
+        models::{
+            ChatReference, MarkMessagesAsReadRequest, Message, ReplyMessageRequest, StickerMessage,
+            TextMessage,
+        },
+    },
+    line_webhook::models::{MessageContent, MessageEvent, Source},
+};
+
+use super::commands;
+
+/// Handles an incoming message event.
+///
+/// First marks messages as read, then dispatches based on the message type.
+/// Text messages starting with '/' are treated as slash commands.
+pub async fn handle(line: &LINE, event: MessageEvent) -> Result<(), String> {
+    // Mark messages as read so the sender sees the blue checkmarks
+    if let Some(user_id) = extract_user_id(&event.source) {
+        let req = MarkMessagesAsReadRequest::new(ChatReference::new(user_id));
+        if let Err(e) = line.messaging_api_client.mark_messages_as_read(req).await {
+            eprintln!("[mark_as_read] failed: {e}");
+        }
+    }
+
+    let reply_token = event.reply_token.ok_or("No reply token")?;
+
+    match *event.message {
+        MessageContent::TextMessageContent(text) => {
+            handle_text(line, reply_token, &text.text, &event.source).await
+        }
+        MessageContent::StickerMessageContent(sticker) => {
+            println!(
+                "[message/sticker] package={} sticker={}",
+                sticker.package_id, sticker.sticker_id
+            );
+            let info = format!("{sticker:#?}");
+            reply(
+                line,
+                reply_token,
+                vec![
+                    Message::TextMessage(TextMessage::new(info)),
+                    Message::StickerMessage(StickerMessage::new(
+                        "11537".to_string(),
+                        "52002734".to_string(),
+                    )),
+                ],
+            )
+            .await
+        }
+        MessageContent::LocationMessageContent(location) => {
+            println!(
+                "[message/location] lat={} lng={}",
+                location.latitude, location.longitude
+            );
+            reply(
+                line,
+                reply_token,
+                vec![Message::TextMessage(TextMessage::new(format!(
+                    "Thanks for sharing your location!\nlat: {}, lng: {}",
+                    location.latitude, location.longitude
+                )))],
+            )
+            .await
+        }
+        MessageContent::ImageMessageContent(image) => {
+            println!("[message/image] id={}", image.id);
+            reply(
+                line,
+                reply_token,
+                vec![Message::TextMessage(TextMessage::new(
+                    "Got your image! Thanks for sharing.".to_string(),
+                ))],
+            )
+            .await
+        }
+        MessageContent::VideoMessageContent(video) => {
+            println!("[message/video] id={}", video.id);
+            reply(
+                line,
+                reply_token,
+                vec![Message::TextMessage(TextMessage::new(
+                    "Got your video! Thanks for sharing.".to_string(),
+                ))],
+            )
+            .await
+        }
+        MessageContent::AudioMessageContent(audio) => {
+            println!("[message/audio] id={}", audio.id);
+            reply(
+                line,
+                reply_token,
+                vec![Message::TextMessage(TextMessage::new(
+                    "Got your audio message! Thanks for sharing.".to_string(),
+                ))],
+            )
+            .await
+        }
+        MessageContent::FileMessageContent(file) => {
+            println!(
+                "[message/file] name={} size={}",
+                file.file_name, file.file_size
+            );
+            reply(
+                line,
+                reply_token,
+                vec![Message::TextMessage(TextMessage::new(format!(
+                    "Got your file: {} ({} bytes)",
+                    file.file_name, file.file_size
+                )))],
+            )
+            .await
+        }
+        _ => {
+            println!("[message/unknown]");
+            reply(
+                line,
+                reply_token,
+                vec![Message::TextMessage(TextMessage::new(
+                    "Received an unknown message type.".to_string(),
+                ))],
+            )
+            .await
+        }
+    }
+}
+
+/// Routes text messages to either slash command handlers or echo reply.
+async fn handle_text(
+    line: &LINE,
+    reply_token: String,
+    text: &str,
+    source: &Option<Box<Source>>,
+) -> Result<(), String> {
+    if let Some(cmd) = text.strip_prefix('/') {
+        let cmd = cmd.split_whitespace().next().unwrap_or("");
+        println!("[command] /{cmd}");
+        match cmd {
+            "help" => commands::help::handle(line, reply_token).await,
+            "leave" => commands::leave::handle(line, reply_token, source).await,
+            "profile" => commands::profile::handle(line, reply_token, source).await,
+            "ginfo" => commands::ginfo::handle(line, reply_token, source).await,
+            "botinfo" => commands::botinfo::handle(line, reply_token).await,
+            "flex" => commands::flex::handle(line, reply_token).await,
+            _ => {
+                reply(
+                    line,
+                    reply_token,
+                    vec![Message::TextMessage(TextMessage::new(format!(
+                        "Unknown command: /{cmd}\nType /help for available commands."
+                    )))],
+                )
+                .await
+            }
+        }
+    } else {
+        println!("[message/text] {text}");
+        reply(
+            line,
+            reply_token,
+            vec![Message::TextMessage(TextMessage::new(text.to_string()))],
+        )
+        .await
+    }
+}
+
+/// Extracts the user ID from any source type (user, group, or room).
+fn extract_user_id(source: &Option<Box<Source>>) -> Option<String> {
+    match source {
+        Some(s) => match s.as_ref() {
+            Source::UserSource(u) => u.user_id.clone(),
+            Source::GroupSource(g) => g.user_id.clone(),
+            Source::RoomSource(r) => r.user_id.clone(),
+            _ => None,
+        },
+        None => None,
+    }
+}
+
+/// Sends a reply message using the given reply token.
+async fn reply(line: &LINE, reply_token: String, messages: Vec<Message>) -> Result<(), String> {
+    let req = ReplyMessageRequest {
+        reply_token,
+        messages,
+        notification_disabled: Some(false),
+    };
+
+    line.messaging_api_client
+        .reply_message(req)
+        .await
+        .map_err(|e| format!("reply_message failed: {e}"))?;
+
+    Ok(())
+}

--- a/examples/axum_example/src/handlers/mod.rs
+++ b/examples/axum_example/src/handlers/mod.rs
@@ -1,0 +1,15 @@
+//! Webhook event handlers.
+//!
+//! Each module handles a specific LINE webhook event type.
+
+pub mod beacon;
+pub mod commands;
+pub mod follow;
+pub mod join;
+pub mod leave;
+pub mod member_joined;
+pub mod member_left;
+pub mod message;
+pub mod postback;
+pub mod unfollow;
+pub mod unsend;

--- a/examples/axum_example/src/handlers/postback.rs
+++ b/examples/axum_example/src/handlers/postback.rs
@@ -1,0 +1,40 @@
+//! Postback event handler.
+//!
+//! Triggered when a user taps a postback action button (e.g., in a rich menu
+//! or template message).
+
+use line_bot_sdk_rust::{
+    client::LINE,
+    line_messaging_api::{
+        apis::MessagingApiApi,
+        models::{Message, ReplyMessageRequest, TextMessage},
+    },
+    line_webhook::models::PostbackEvent,
+};
+
+/// Replies with the postback data and any associated parameters.
+pub async fn handle(line: &LINE, event: PostbackEvent) -> Result<(), String> {
+    let reply_token = event.reply_token.ok_or("No reply token")?;
+
+    println!("[postback] data={}", event.postback.data);
+
+    let mut text = format!("Postback received!\ndata: {}", event.postback.data);
+    if let Some(params) = &event.postback.params {
+        for (k, v) in params {
+            text.push_str(&format!("\n{k}: {v}"));
+        }
+    }
+
+    let req = ReplyMessageRequest {
+        reply_token,
+        messages: vec![Message::TextMessage(TextMessage::new(text))],
+        notification_disabled: Some(false),
+    };
+
+    line.messaging_api_client
+        .reply_message(req)
+        .await
+        .map_err(|e| format!("reply_message failed: {e}"))?;
+
+    Ok(())
+}

--- a/examples/axum_example/src/handlers/unfollow.rs
+++ b/examples/axum_example/src/handlers/unfollow.rs
@@ -1,0 +1,13 @@
+//! Unfollow event handler.
+//!
+//! Triggered when a user blocks or removes the bot. No reply is possible.
+
+use line_bot_sdk_rust::line_webhook::models::UnfollowEvent;
+
+pub fn handle(event: UnfollowEvent) -> Result<(), String> {
+    println!(
+        "[unfollow] User unfollowed (event_id: {})",
+        event.webhook_event_id
+    );
+    Ok(())
+}

--- a/examples/axum_example/src/handlers/unsend.rs
+++ b/examples/axum_example/src/handlers/unsend.rs
@@ -1,0 +1,13 @@
+//! Unsend event handler.
+//!
+//! Triggered when a user unsends (deletes) a message. No reply is sent.
+
+use line_bot_sdk_rust::line_webhook::models::UnsendEvent;
+
+pub fn handle(event: UnsendEvent) -> Result<(), String> {
+    println!(
+        "[unsend] Message unsent (message_id: {})",
+        event.unsend.message_id
+    );
+    Ok(())
+}

--- a/examples/axum_example/src/main.rs
+++ b/examples/axum_example/src/main.rs
@@ -1,17 +1,24 @@
+//! Axum example for line-bot-sdk-rust.
+//!
+//! This example demonstrates how to build a LINE bot using the Axum web framework.
+//! It handles webhook callbacks, validates signatures, and dispatches events
+//! to the appropriate handlers.
+
+mod handler;
+mod handlers;
+
 use axum::{routing::post, Router};
 use dotenvy::dotenv;
 use line_bot_sdk_rust::{
-    client::LINE,
-    line_messaging_api::{
-        apis::MessagingApiApi,
-        models::{Message, ReplyMessageRequest, TextMessage},
-    },
-    line_webhook::models::{CallbackRequest, Event, MessageContent},
-    parser::signature::validate_signature,
+    client::LINE, line_webhook::models::CallbackRequest, parser::signature::validate_signature,
     support::axum::Signature,
 };
 use std::env;
 
+/// Webhook callback endpoint.
+///
+/// Receives LINE webhook events, validates the signature, parses the request,
+/// and dispatches each event to the appropriate handler.
 async fn callback(
     signature: Signature,
     body: String,
@@ -23,6 +30,7 @@ async fn callback(
 
     let line = LINE::new(access_token);
 
+    // Verify the request signature using the channel secret
     if !validate_signature(&channel_secret, &signature.key, &body) {
         return Err((
             axum::http::StatusCode::BAD_REQUEST,
@@ -37,26 +45,9 @@ async fn callback(
         )
     })?;
 
-    println!("req: {request:#?}");
-
-    for e in request.events {
-        if let Event::MessageEvent(message_event) = e {
-            if let MessageContent::TextMessageContent(text_message) = *message_event.message {
-                let reply_message_request = ReplyMessageRequest {
-                    reply_token: message_event.reply_token.unwrap(),
-                    messages: vec![Message::TextMessage(TextMessage::new(text_message.text))],
-                    notification_disabled: Some(false),
-                };
-                let result = line
-                    .messaging_api_client
-                    .reply_message(reply_message_request)
-                    .await;
-                match result {
-                    Ok(r) => println!("{r:#?}"),
-                    Err(e) => println!("{e:#?}"),
-                }
-            }
-        }
+    // Dispatch each event to the appropriate handler
+    for event in request.events {
+        handler::handle_event(&line, event).await;
     }
 
     Ok("ok")
@@ -68,7 +59,7 @@ async fn main() {
 
     let app = Router::new().route("/callback", post(callback));
 
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:8080")
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:3000")
         .await
         .unwrap();
     println!("Listening on {}", listener.local_addr().unwrap());


### PR DESCRIPTION
## Summary
- Refactored the minimal echo-bot axum example into a full-featured webhook handler
- Added modular handlers for all major event types: follow, unfollow, join, leave, postback, beacon, member joined/left, unsend
- Added slash command handlers: `/help`, `/profile`, `/botinfo`, `/ginfo`, `/flex`, `/leave`
- All handlers include English doc comments (`//!` module docs and `///` function docs)

## Test plan
- [x] `cargo build --manifest-path examples/axum_example/Cargo.toml` passes
- [x] `cargo fmt` check passes
- [ ] Manual testing with LINE webhook events

🤖 Generated with [Claude Code](https://claude.com/claude-code)