### PR TITLE
Fix duplicate type field in tagged enum serialization

### DIFF
--- a/core/line_messaging_api/src/models/flex_box.rs
+++ b/core/line_messaging_api/src/models/flex_box.rs
@@ -29,11 +29,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct FlexBox {
-    #[serde(
-        rename = "type",
-        default = "FlexBox::default_type",
-        skip_serializing_if = "String::is_empty"
-    )]
+    #[serde(rename = "type", default, skip_serializing_if = "String::is_empty")]
     pub r#type: String,
     #[serde(rename = "layout")]
     pub layout: Layout,
@@ -92,10 +88,6 @@ pub struct FlexBox {
 }
 
 impl FlexBox {
-    fn default_type() -> String {
-        "box".to_string()
-    }
-
     pub fn new(layout: Layout, contents: Vec<models::FlexComponent>) -> FlexBox {
         FlexBox {
             r#type: "box".to_string(),

--- a/core/line_messaging_api/src/models/flex_bubble.rs
+++ b/core/line_messaging_api/src/models/flex_bubble.rs
@@ -29,11 +29,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct FlexBubble {
-    #[serde(
-        rename = "type",
-        default = "FlexBubble::default_type",
-        skip_serializing_if = "String::is_empty"
-    )]
+    #[serde(rename = "type", default, skip_serializing_if = "String::is_empty")]
     pub r#type: String,
     #[serde(rename = "direction", skip_serializing_if = "Option::is_none")]
     pub direction: Option<Direction>,
@@ -54,10 +50,6 @@ pub struct FlexBubble {
 }
 
 impl FlexBubble {
-    fn default_type() -> String {
-        "bubble".to_string()
-    }
-
     pub fn new() -> FlexBubble {
         FlexBubble {
             r#type: "bubble".to_string(),

--- a/core/line_messaging_api/src/models/flex_span.rs
+++ b/core/line_messaging_api/src/models/flex_span.rs
@@ -29,11 +29,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct FlexSpan {
-    #[serde(
-        rename = "type",
-        default = "FlexSpan::default_type",
-        skip_serializing_if = "String::is_empty"
-    )]
+    #[serde(rename = "type", default, skip_serializing_if = "String::is_empty")]
     pub r#type: String,
     #[serde(rename = "text", skip_serializing_if = "Option::is_none")]
     pub text: Option<String>,
@@ -50,10 +46,6 @@ pub struct FlexSpan {
 }
 
 impl FlexSpan {
-    fn default_type() -> String {
-        "span".to_string()
-    }
-
     pub fn new() -> FlexSpan {
         FlexSpan {
             r#type: "span".to_string(),

--- a/core/line_messaging_api/tests/deserialization.rs
+++ b/core/line_messaging_api/tests/deserialization.rs
@@ -106,7 +106,9 @@ fn flex_container_deserialize_via_tagged_enum() {
     let container: FlexContainer = serde_json::from_str(json).unwrap();
     match &container {
         FlexContainer::FlexBubble(b) => {
-            assert_eq!(b.r#type, "bubble");
+            // When deserialized via tagged enum, serde strips the "type" field
+            // so the struct's type field gets the default empty string.
+            assert_eq!(b.r#type, "");
         }
         _ => panic!("expected FlexBubble"),
     }
@@ -118,7 +120,8 @@ fn flex_component_deserialize_via_tagged_enum() {
     let component: FlexComponent = serde_json::from_str(json).unwrap();
     match &component {
         FlexComponent::FlexBox(b) => {
-            assert_eq!(b.r#type, "box");
+            // When deserialized via tagged enum, the type field is empty.
+            assert_eq!(b.r#type, "");
             assert!(b.contents.is_empty());
         }
         _ => panic!("expected FlexBox"),

--- a/core/line_webhook/src/models/user_source.rs
+++ b/core/line_webhook/src/models/user_source.rs
@@ -29,11 +29,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct UserSource {
-    #[serde(
-        rename = "type",
-        default = "UserSource::default_type",
-        skip_serializing_if = "String::is_empty"
-    )]
+    #[serde(rename = "type", default, skip_serializing_if = "String::is_empty")]
     pub r#type: String,
     /// ID of the source user
     #[serde(rename = "userId", skip_serializing_if = "Option::is_none")]
@@ -41,10 +37,6 @@ pub struct UserSource {
 }
 
 impl UserSource {
-    fn default_type() -> String {
-        "user".to_string()
-    }
-
     pub fn new() -> UserSource {
         UserSource {
             r#type: "user".to_string(),

--- a/core/line_webhook/tests/deserialization.rs
+++ b/core/line_webhook/tests/deserialization.rs
@@ -12,7 +12,8 @@ fn deserialize_user_source() {
     let source: Source = serde_json::from_str(json).unwrap();
     match &source {
         Source::UserSource(s) => {
-            assert_eq!(s.r#type, "user");
+            // When deserialized via tagged enum, serde strips "type" so it defaults to "".
+            assert_eq!(s.r#type, "");
             assert_eq!(
                 s.user_id.as_deref(),
                 Some("U1234567890abcdef1234567890abcdef")

--- a/generator/src/main/resources/line-bot-sdk-rust-generator/model.pebble
+++ b/generator/src/main/resources/line-bot-sdk-rust-generator/model.pebble
@@ -97,7 +97,7 @@ impl Default for {{ model.classname }} {
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct {{ model.classname }} {
 {% if model.vendorExtensions['x-needs-type-field'] is not null and model.vendorExtensions['x-needs-type-field'] == true -%}
-    #[serde(rename = "{{ model.vendorExtensions['x-discriminator-property'] }}", default = "{{ model.classname }}::default_type", skip_serializing_if = "String::is_empty")]
+    #[serde(rename = "{{ model.vendorExtensions['x-discriminator-property'] }}", default, skip_serializing_if = "String::is_empty")]
     pub r#type: String,
 {% endif -%}
 {% for var in model.vars -%}
@@ -110,12 +110,6 @@ pub struct {{ model.classname }} {
 }
 
 impl {{ model.classname }} {
-{% if model.vendorExtensions['x-needs-type-field'] is not null and model.vendorExtensions['x-needs-type-field'] == true -%}
-    fn default_type() -> String {
-        "{{ model.vendorExtensions['x-discriminator-value'] }}".to_string()
-    }
-
-{% endif -%}
 {% if model.description is not empty -%}
     /// {{ model.description }}
 {% endif -%}


### PR DESCRIPTION
## Summary
- Discriminator child structs (FlexBox, FlexBubble, FlexSpan, UserSource) produced duplicate `"type"` JSON keys when serialized through a `#[serde(tag = "type")]` enum
- LINE API rejects duplicate keys with `400 Bad Request: Duplicate field 'type'`
- **Fix**: Use `#[serde(default)]` (empty string) instead of `default = "ClassName::default_type"` on the type field
  - Tagged enum deserialization: serde strips `"type"`, field defaults to `""`, `skip_serializing_if = "String::is_empty"` omits it → no duplicate
  - Standalone deserialization: `"type"` is read from JSON normally → preserved
  - `new()` constructor: sets type value explicitly → preserved

This supersedes the approach from #119 which used `default_type()` returning the actual value, causing serialization duplicates.

## Test plan
- [x] `cargo test --tests` — 20/20 passed
- [x] `cargo build` passes
- [ ] Manual testing: `/flex` command sends Flex Message without 400 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)