### PR TITLE
Clean up unused deps, CI workflows, and dead code

### DIFF
--- a/.github/workflows/generate_modules.yml
+++ b/.github/workflows/generate_modules.yml
@@ -9,6 +9,18 @@ on:
       - "tools/**"
       - "core/line_*/**"
       - "generate-code.py"
+
+  push:
+    branches:
+      - develop
+    paths:
+      - .github/workflows/generate_modules.yml
+      - "line-openapi"
+      - "generator/**"
+      - "tools/**"
+      - "core/line_*/**"
+      - "generate-code.py"
+
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
       - name: publish
         run: make publish
         env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,16 +52,16 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Clippy
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
       - name: Clippy with rocket_support
-        run: cargo clippy --all-targets --features rocket_support -- -D warnings
+        run: cargo clippy --workspace --all-targets --features rocket_support -- -D warnings
 
       - name: Clippy with actix_support
-        run: cargo clippy --all-targets --features actix_support -- -D warnings
+        run: cargo clippy --workspace --all-targets --features actix_support -- -D warnings
 
       - name: Clippy with axum_support
-        run: cargo clippy --all-targets --features axum_support -- -D warnings
+        run: cargo clippy --workspace --all-targets --features axum_support -- -D warnings
 
       - name: Clippy for examples
         run: cargo clippy --all-targets -- -D warnings
@@ -85,19 +85,19 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Build
-        run: cargo build --verbose
+        run: cargo build --workspace --verbose
 
       - name: Run tests
-        run: cargo test --verbose
+        run: cargo test --workspace --verbose
 
       - name: Build with rocket_support
-        run: cargo build --verbose --features rocket_support
+        run: cargo build --workspace --verbose --features rocket_support
 
       - name: Build with actix_support
-        run: cargo build --verbose --features actix_support
+        run: cargo build --workspace --verbose --features actix_support
 
       - name: Build with axum_support
-        run: cargo build --verbose --features axum_support
+        run: cargo build --workspace --verbose --features axum_support
 
       - name: Build for examples
         run: cargo build --verbose
@@ -117,4 +117,4 @@ jobs:
         run: cargo install cargo-audit
 
       - name: Run audit
-        run: cargo audit --ignore RUSTSEC-2019-0020 --ignore RUSTSEC-2020-0151
+        run: cargo audit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ members = [
 serde = "^1.0"
 serde_json = "^1.0"
 serde_repr = "^0.1"
-serde_with = "^3.17"
 url = "^2.5"
 uuid = "^1.22"
 hyper = "^1.8"

--- a/generate-code.py
+++ b/generate-code.py
@@ -36,15 +36,6 @@ SERVICES = [
     ("webhook.yml", "core/line_webhook", "line_webhook"),
 ]
 
-# Hand-written source files that override generated ones
-HAND_WRITTEN_SOURCES = [
-    "messaging_api/src/models/message.rs",
-    "webhook/src/models/event.rs",
-    "webhook/src/models/message_content.rs",
-    "webhook/src/models/source.rs",
-]
-
-
 def read_version(cargo_toml: str) -> str:
     """Read version from an existing Cargo.toml."""
     if not os.path.exists(cargo_toml):
@@ -202,17 +193,6 @@ def post_process_manage_audience() -> None:
                 f.write(modified)
 
 
-def copy_hand_written_sources() -> None:
-    """Copy hand-written source files over generated ones."""
-    print("Copying hand-written sources...")
-    for source in HAND_WRITTEN_SOURCES:
-        src = os.path.join(ROOT, "tools", "sources", source)
-        dst = os.path.join(ROOT, "core", f"line_{source}")
-        if os.path.exists(src):
-            shutil.copy2(src, dst)
-            print(f"  {source}")
-
-
 def cargo_fix() -> None:
     """Run cargo fix to auto-rename unused variables."""
     print("Running cargo fix...")
@@ -257,9 +237,6 @@ def main() -> None:
         api_dir = os.path.join(ROOT, output_dir, "src", "apis")
         _fix_blank_line_before_execute(api_dir)
     post_process_manage_audience()
-
-    # Copy hand-written sources over generated ones
-    copy_hand_written_sources()
 
     cargo_fix()
     format_code()

--- a/generate-code.py
+++ b/generate-code.py
@@ -36,6 +36,7 @@ SERVICES = [
     ("webhook.yml", "core/line_webhook", "line_webhook"),
 ]
 
+
 def read_version(cargo_toml: str) -> str:
     """Read version from an existing Cargo.toml."""
     if not os.path.exists(cargo_toml):


### PR DESCRIPTION
## Summary
- Remove unused `serde_with` from workspace dependencies
- Add `--workspace` flag to `cargo build`/`test`/`clippy` in CI for explicit workspace coverage
- Remove stale `cargo-audit` ignores (`RUSTSEC-2019-0020` spin, `RUSTSEC-2020-0151` net2 — neither is in the dependency tree)
- Add explicit Rust toolchain setup (`dtolnay/rust-toolchain@stable`) to publish workflow
- Add `push` trigger for `develop` branch to `generate_modules` workflow (consistent with `rust.yml`)
- Remove dead `HAND_WRITTEN_SOURCES` and `copy_hand_written_sources()` from `generate-code.py` (`tools/sources/` directory doesn't exist)

## Additional notes (for follow-up PRs)
These require `make generate` (Java/Maven) and are out of scope for this PR:
- `uuid` and `serde_repr` are declared in all 9 generated sub-crate `Cargo.toml` but never used — should be made conditional in `Cargo.toml.pebble`
- Generated sub-crates lack `rust-version` — should be added to `Cargo.toml.pebble`

## Test plan
- [x] `cargo build --workspace` passes
- [x] `cargo test --workspace` passes (47 tests)
- [x] `cargo clippy --workspace --all-targets` passes (0 warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)