### PR TITLE
Add comprehensive webhook and messaging API examples

### DIFF
--- a/examples/axum_example/src/handler.rs
+++ b/examples/axum_example/src/handler.rs
@@ -22,6 +22,8 @@ pub async fn handle_event(line: &LINE, event: Event) {
         Event::PostbackEvent(e) => handlers::postback::handle(line, e).await,
         Event::UnsendEvent(e) => handlers::unsend::handle(e),
         Event::BeaconEvent(e) => handlers::beacon::handle(line, e).await,
+        Event::VideoPlayCompleteEvent(e) => handlers::video_play_complete::handle(line, e).await,
+        Event::AccountLinkEvent(e) => handlers::account_link::handle(line, e).await,
         _ => {
             println!("[unhandled event]");
             Ok(())

--- a/examples/axum_example/src/handlers/account_link.rs
+++ b/examples/axum_example/src/handlers/account_link.rs
@@ -1,0 +1,45 @@
+//! Account link event handler.
+//!
+//! Triggered when a user completes or fails the account linking flow.
+
+use line_bot_sdk_rust::{
+    client::LINE,
+    line_messaging_api::{
+        apis::MessagingApiApi,
+        models::{Message, ReplyMessageRequest, TextMessage},
+    },
+    line_webhook::models::AccountLinkEvent,
+};
+
+/// Replies with the account linking result (success/failure) and nonce.
+pub async fn handle(line: &LINE, event: AccountLinkEvent) -> Result<(), String> {
+    let link = &event.link;
+    println!(
+        "[account_link] result={:?} nonce={}",
+        link.result, link.nonce
+    );
+
+    let reply_token = event.reply_token.ok_or("No reply token")?;
+
+    let text = format!(
+        "Account linking {}\nnonce: {}",
+        match link.result {
+            line_bot_sdk_rust::line_webhook::models::link_content::Result::Ok => "succeeded!",
+            _ => "failed.",
+        },
+        link.nonce
+    );
+
+    let req = ReplyMessageRequest {
+        reply_token,
+        messages: vec![Message::TextMessage(TextMessage::new(text))],
+        notification_disabled: Some(false),
+    };
+
+    line.messaging_api_client
+        .reply_message(req)
+        .await
+        .map_err(|e| format!("reply_message failed: {e}"))?;
+
+    Ok(())
+}

--- a/examples/axum_example/src/handlers/commands/carousel.rs
+++ b/examples/axum_example/src/handlers/commands/carousel.rs
@@ -1,0 +1,85 @@
+//! `/carousel` command handler.
+//!
+//! Demonstrates sending a CarouselTemplate with multiple columns.
+
+use line_bot_sdk_rust::{
+    client::LINE,
+    line_messaging_api::{
+        apis::MessagingApiApi,
+        models::{
+            Action, CarouselColumn, CarouselTemplate, Message, MessageAction, ReplyMessageRequest,
+            Template, TemplateMessage, UriAction,
+        },
+    },
+};
+
+/// Sends a carousel template showcasing multiple LINE API services.
+pub async fn handle(line: &LINE, reply_token: String) -> Result<(), String> {
+    let columns = vec![
+        CarouselColumn {
+            title: Some("Messaging API".to_string()),
+            text: "Send and receive messages, manage rich menus, and more.".to_string(),
+            actions: vec![
+                Action::UriAction(UriAction {
+                    label: Some("Documentation".to_string()),
+                    uri: Some("https://developers.line.biz/en/docs/messaging-api/".to_string()),
+                    ..Default::default()
+                }),
+                Action::MessageAction(MessageAction {
+                    label: Some("Try /botinfo".to_string()),
+                    text: Some("/botinfo".to_string()),
+                }),
+            ],
+            ..CarouselColumn::new(String::new(), vec![])
+        },
+        CarouselColumn {
+            title: Some("Flex Message".to_string()),
+            text: "Build highly customizable message layouts with JSON.".to_string(),
+            actions: vec![
+                Action::UriAction(UriAction {
+                    label: Some("Simulator".to_string()),
+                    uri: Some("https://developers.line.biz/flex-simulator/".to_string()),
+                    ..Default::default()
+                }),
+                Action::MessageAction(MessageAction {
+                    label: Some("Try /flex".to_string()),
+                    text: Some("/flex".to_string()),
+                }),
+            ],
+            ..CarouselColumn::new(String::new(), vec![])
+        },
+        CarouselColumn {
+            title: Some("LIFF".to_string()),
+            text: "Build web apps that run inside the LINE client.".to_string(),
+            actions: vec![
+                Action::UriAction(UriAction {
+                    label: Some("Documentation".to_string()),
+                    uri: Some("https://developers.line.biz/en/docs/liff/".to_string()),
+                    ..Default::default()
+                }),
+                Action::UriAction(UriAction {
+                    label: Some("Playground".to_string()),
+                    uri: Some("https://liff-playground.netlify.app/".to_string()),
+                    ..Default::default()
+                }),
+            ],
+            ..CarouselColumn::new(String::new(), vec![])
+        },
+    ];
+
+    let req = ReplyMessageRequest {
+        reply_token,
+        messages: vec![Message::TemplateMessage(TemplateMessage::new(
+            "LINE Platform Services".to_string(),
+            Template::CarouselTemplate(CarouselTemplate::new(columns)),
+        ))],
+        notification_disabled: Some(false),
+    };
+
+    line.messaging_api_client
+        .reply_message(req)
+        .await
+        .map_err(|e| format!("reply_message failed: {e}"))?;
+
+    Ok(())
+}

--- a/examples/axum_example/src/handlers/commands/confirm.rs
+++ b/examples/axum_example/src/handlers/commands/confirm.rs
@@ -1,0 +1,51 @@
+//! `/confirm` command handler.
+//!
+//! Demonstrates sending a ConfirmTemplate.
+
+use line_bot_sdk_rust::{
+    client::LINE,
+    line_messaging_api::{
+        apis::MessagingApiApi,
+        models::{
+            Action, ConfirmTemplate, Message, PostbackAction, ReplyMessageRequest, Template,
+            TemplateMessage,
+        },
+    },
+};
+
+/// Sends a confirm template with Yes/No postback actions.
+pub async fn handle(line: &LINE, reply_token: String) -> Result<(), String> {
+    let confirm = ConfirmTemplate::new(
+        "Do you like the LINE Bot SDK for Rust?".to_string(),
+        vec![
+            Action::PostbackAction(PostbackAction {
+                label: Some("Yes!".to_string()),
+                data: Some("answer=yes".to_string()),
+                display_text: Some("Yes, I love it!".to_string()),
+                ..Default::default()
+            }),
+            Action::PostbackAction(PostbackAction {
+                label: Some("No...".to_string()),
+                data: Some("answer=no".to_string()),
+                display_text: Some("Not really...".to_string()),
+                ..Default::default()
+            }),
+        ],
+    );
+
+    let req = ReplyMessageRequest {
+        reply_token,
+        messages: vec![Message::TemplateMessage(TemplateMessage::new(
+            "Confirm".to_string(),
+            Template::ConfirmTemplate(confirm),
+        ))],
+        notification_disabled: Some(false),
+    };
+
+    line.messaging_api_client
+        .reply_message(req)
+        .await
+        .map_err(|e| format!("reply_message failed: {e}"))?;
+
+    Ok(())
+}

--- a/examples/axum_example/src/handlers/commands/help.rs
+++ b/examples/axum_example/src/handlers/commands/help.rs
@@ -14,12 +14,30 @@ use line_bot_sdk_rust::{
 pub async fn handle(line: &LINE, reply_token: String) -> Result<(), String> {
     let text = "\
 Available commands:
-/help - Show this help message
-/profile - Show your profile info
-/botinfo - Show bot info
-/ginfo - Show group info (group only)
-/flex - Send a Flex Message sample
-/leave - Leave the current group/room (group only)"
+
+[Message Types]
+/flex - Flex Message (from JSON)
+/image - Image message
+/location - Location message
+/template - Buttons template
+/confirm - Confirm template
+/carousel - Carousel template
+/quick - Quick reply buttons
+
+[API Features]
+/profile - Your profile info
+/botinfo - Bot info
+/ginfo - Group info (group only)
+/members - Group member list (group only)
+/push - Push message demo
+/loading - Loading animation
+/quota - Message quota info
+/richmenu - Rich menu list
+/webhook - Webhook endpoint info
+
+[Actions]
+/leave - Leave group/room (group only)
+/help - Show this help"
         .to_string();
 
     let req = ReplyMessageRequest {

--- a/examples/axum_example/src/handlers/commands/image.rs
+++ b/examples/axum_example/src/handlers/commands/image.rs
@@ -1,0 +1,29 @@
+//! `/image` command handler.
+//!
+//! Demonstrates sending an ImageMessage.
+
+use line_bot_sdk_rust::{
+    client::LINE,
+    line_messaging_api::{
+        apis::MessagingApiApi,
+        models::{ImageMessage, Message, ReplyMessageRequest},
+    },
+};
+
+/// Sends a sample image message.
+pub async fn handle(line: &LINE, reply_token: String) -> Result<(), String> {
+    let url = "https://rustacean.net/assets/rustacean-flat-happy.png".to_string();
+
+    let req = ReplyMessageRequest {
+        reply_token,
+        messages: vec![Message::ImageMessage(ImageMessage::new(url.clone(), url))],
+        notification_disabled: Some(false),
+    };
+
+    line.messaging_api_client
+        .reply_message(req)
+        .await
+        .map_err(|e| format!("reply_message failed: {e}"))?;
+
+    Ok(())
+}

--- a/examples/axum_example/src/handlers/commands/loading.rs
+++ b/examples/axum_example/src/handlers/commands/loading.rs
@@ -1,0 +1,57 @@
+//! `/loading` command handler.
+//!
+//! Demonstrates the Show Loading Animation API.
+
+use line_bot_sdk_rust::{
+    client::LINE,
+    line_messaging_api::{
+        apis::MessagingApiApi,
+        models::{Message, ReplyMessageRequest, ShowLoadingAnimationRequest, TextMessage},
+    },
+    line_webhook::models::Source,
+};
+
+/// Shows a loading animation to the user, then replies after a brief delay.
+pub async fn handle(
+    line: &LINE,
+    reply_token: String,
+    source: &Option<Box<Source>>,
+) -> Result<(), String> {
+    let user_id = match source {
+        Some(s) => match s.as_ref() {
+            Source::UserSource(u) => u.user_id.clone(),
+            Source::GroupSource(g) => g.user_id.clone(),
+            Source::RoomSource(r) => r.user_id.clone(),
+            _ => None,
+        },
+        None => None,
+    };
+
+    if let Some(uid) = user_id {
+        let mut loading_req = ShowLoadingAnimationRequest::new(uid);
+        loading_req.loading_seconds = Some(5);
+
+        if let Err(e) = line
+            .messaging_api_client
+            .show_loading_animation(loading_req)
+            .await
+        {
+            eprintln!("[loading] show_loading_animation failed: {e}");
+        }
+    }
+
+    let req = ReplyMessageRequest {
+        reply_token,
+        messages: vec![Message::TextMessage(TextMessage::new(
+            "Loading animation was displayed for 5 seconds!".to_string(),
+        ))],
+        notification_disabled: Some(false),
+    };
+
+    line.messaging_api_client
+        .reply_message(req)
+        .await
+        .map_err(|e| format!("reply_message failed: {e}"))?;
+
+    Ok(())
+}

--- a/examples/axum_example/src/handlers/commands/location.rs
+++ b/examples/axum_example/src/handlers/commands/location.rs
@@ -1,0 +1,32 @@
+//! `/location` command handler.
+//!
+//! Demonstrates sending a LocationMessage.
+
+use line_bot_sdk_rust::{
+    client::LINE,
+    line_messaging_api::{
+        apis::MessagingApiApi,
+        models::{LocationMessage, Message, ReplyMessageRequest},
+    },
+};
+
+/// Sends the LINE Corporation headquarters as a sample location message.
+pub async fn handle(line: &LINE, reply_token: String) -> Result<(), String> {
+    let req = ReplyMessageRequest {
+        reply_token,
+        messages: vec![Message::LocationMessage(LocationMessage::new(
+            "LINE Corporation".to_string(),
+            "4-1-6 Shinjuku, Shinjuku-ku, Tokyo".to_string(),
+            35.6895,
+            139.7004,
+        ))],
+        notification_disabled: Some(false),
+    };
+
+    line.messaging_api_client
+        .reply_message(req)
+        .await
+        .map_err(|e| format!("reply_message failed: {e}"))?;
+
+    Ok(())
+}

--- a/examples/axum_example/src/handlers/commands/members.rs
+++ b/examples/axum_example/src/handlers/commands/members.rs
@@ -1,0 +1,70 @@
+//! `/members` command handler.
+//!
+//! Lists member IDs in the current group or room.
+
+use line_bot_sdk_rust::{
+    client::LINE,
+    line_messaging_api::{
+        apis::MessagingApiApi,
+        models::{Message, ReplyMessageRequest, TextMessage},
+    },
+    line_webhook::models::Source,
+};
+
+/// Fetches group/room member IDs and replies with the list.
+pub async fn handle(
+    line: &LINE,
+    reply_token: String,
+    source: &Option<Box<Source>>,
+) -> Result<(), String> {
+    let text = match source.as_deref() {
+        Some(Source::GroupSource(g)) => {
+            match line
+                .messaging_api_client
+                .get_group_members_ids(&g.group_id, None)
+                .await
+            {
+                Ok(res) => {
+                    let count = res.member_ids.len();
+                    let ids: Vec<_> = res.member_ids.iter().take(10).cloned().collect();
+                    let mut text = format!("Group members ({count} fetched):\n");
+                    for id in &ids {
+                        text.push_str(&format!("- {id}\n"));
+                    }
+                    if count > 10 {
+                        text.push_str(&format!("... and {} more", count - 10));
+                    }
+                    text
+                }
+                Err(e) => format!("Failed to get members: {e}"),
+            }
+        }
+        Some(Source::RoomSource(r)) => {
+            match line
+                .messaging_api_client
+                .get_room_members_ids(&r.room_id, None)
+                .await
+            {
+                Ok(res) => {
+                    let count = res.member_ids.len();
+                    format!("Room members ({count} fetched)")
+                }
+                Err(e) => format!("Failed to get members: {e}"),
+            }
+        }
+        _ => "This command can only be used in a group or room.".to_string(),
+    };
+
+    let req = ReplyMessageRequest {
+        reply_token,
+        messages: vec![Message::TextMessage(TextMessage::new(text))],
+        notification_disabled: Some(false),
+    };
+
+    line.messaging_api_client
+        .reply_message(req)
+        .await
+        .map_err(|e| format!("reply_message failed: {e}"))?;
+
+    Ok(())
+}

--- a/examples/axum_example/src/handlers/commands/mod.rs
+++ b/examples/axum_example/src/handlers/commands/mod.rs
@@ -3,8 +3,20 @@
 //! Each submodule handles a specific `/command` sent as a text message.
 
 pub mod botinfo;
+pub mod carousel;
+pub mod confirm;
 pub mod flex;
 pub mod ginfo;
 pub mod help;
+pub mod image;
 pub mod leave;
+pub mod loading;
+pub mod location;
+pub mod members;
 pub mod profile;
+pub mod push;
+pub mod quick;
+pub mod quota;
+pub mod richmenu;
+pub mod template;
+pub mod webhook_info;

--- a/examples/axum_example/src/handlers/commands/push.rs
+++ b/examples/axum_example/src/handlers/commands/push.rs
@@ -1,0 +1,60 @@
+//! `/push` command handler.
+//!
+//! Demonstrates the Push Message API by sending a message outside of a reply.
+
+use line_bot_sdk_rust::{
+    client::LINE,
+    line_messaging_api::{
+        apis::MessagingApiApi,
+        models::{Message, PushMessageRequest, ReplyMessageRequest, TextMessage},
+    },
+    line_webhook::models::Source,
+};
+
+/// Replies with a confirmation, then sends a separate push message to the user.
+pub async fn handle(
+    line: &LINE,
+    reply_token: String,
+    source: &Option<Box<Source>>,
+) -> Result<(), String> {
+    // First, reply to acknowledge the command
+    let req = ReplyMessageRequest {
+        reply_token,
+        messages: vec![Message::TextMessage(TextMessage::new(
+            "Sending you a push message...".to_string(),
+        ))],
+        notification_disabled: Some(false),
+    };
+
+    line.messaging_api_client
+        .reply_message(req)
+        .await
+        .map_err(|e| format!("reply_message failed: {e}"))?;
+
+    // Then, send a push message (not a reply)
+    let user_id = match source {
+        Some(s) => match s.as_ref() {
+            Source::UserSource(u) => u.user_id.clone(),
+            Source::GroupSource(g) => g.user_id.clone(),
+            Source::RoomSource(r) => r.user_id.clone(),
+            _ => None,
+        },
+        None => None,
+    };
+
+    if let Some(uid) = user_id {
+        let push_req = PushMessageRequest::new(
+            uid,
+            vec![Message::TextMessage(TextMessage::new(
+                "This is a push message sent via the Push Message API!".to_string(),
+            ))],
+        );
+
+        line.messaging_api_client
+            .push_message(push_req, None)
+            .await
+            .map_err(|e| format!("push_message failed: {e}"))?;
+    }
+
+    Ok(())
+}

--- a/examples/axum_example/src/handlers/commands/quick.rs
+++ b/examples/axum_example/src/handlers/commands/quick.rs
@@ -1,0 +1,64 @@
+//! `/quick` command handler.
+//!
+//! Demonstrates sending a message with QuickReply buttons.
+
+use line_bot_sdk_rust::{
+    client::LINE,
+    line_messaging_api::{
+        apis::MessagingApiApi,
+        models::{
+            Action, CameraAction, CameraRollAction, LocationAction, Message, MessageAction,
+            PostbackAction, QuickReply, QuickReplyItem, ReplyMessageRequest, TextMessage,
+        },
+    },
+};
+
+/// Sends a text message with quick reply buttons demonstrating various action types.
+pub async fn handle(line: &LINE, reply_token: String) -> Result<(), String> {
+    fn item(action: Action) -> QuickReplyItem {
+        QuickReplyItem {
+            action: Some(Box::new(action)),
+            ..Default::default()
+        }
+    }
+
+    let quick_reply = QuickReply {
+        items: Some(vec![
+            item(Action::MessageAction(MessageAction {
+                label: Some("Hello".to_string()),
+                text: Some("Hello!".to_string()),
+            })),
+            item(Action::PostbackAction(PostbackAction {
+                label: Some("Postback".to_string()),
+                data: Some("quick=postback".to_string()),
+                display_text: Some("Postback tapped".to_string()),
+                ..Default::default()
+            })),
+            item(Action::CameraAction(CameraAction {
+                label: Some("Camera".to_string()),
+            })),
+            item(Action::CameraRollAction(CameraRollAction {
+                label: Some("Album".to_string()),
+            })),
+            item(Action::LocationAction(LocationAction {
+                label: Some("Location".to_string()),
+            })),
+        ]),
+    };
+
+    let mut msg = TextMessage::new("Tap a quick reply button below:".to_string());
+    msg.quick_reply = Some(Box::new(quick_reply));
+
+    let req = ReplyMessageRequest {
+        reply_token,
+        messages: vec![Message::TextMessage(msg)],
+        notification_disabled: Some(false),
+    };
+
+    line.messaging_api_client
+        .reply_message(req)
+        .await
+        .map_err(|e| format!("reply_message failed: {e}"))?;
+
+    Ok(())
+}

--- a/examples/axum_example/src/handlers/commands/quota.rs
+++ b/examples/axum_example/src/handlers/commands/quota.rs
@@ -1,0 +1,43 @@
+//! `/quota` command handler.
+//!
+//! Displays the bot's message quota and current consumption.
+
+use line_bot_sdk_rust::{
+    client::LINE,
+    line_messaging_api::{
+        apis::MessagingApiApi,
+        models::{Message, ReplyMessageRequest, TextMessage},
+    },
+};
+
+/// Fetches message quota and consumption, then replies with the information.
+pub async fn handle(line: &LINE, reply_token: String) -> Result<(), String> {
+    let mut parts = Vec::new();
+
+    match line.messaging_api_client.get_message_quota().await {
+        Ok(quota) => parts.push(format!("[Quota]\n{quota:#?}")),
+        Err(e) => parts.push(format!("[Quota] Error: {e}")),
+    }
+
+    match line
+        .messaging_api_client
+        .get_message_quota_consumption()
+        .await
+    {
+        Ok(consumption) => parts.push(format!("[Consumption]\n{consumption:#?}")),
+        Err(e) => parts.push(format!("[Consumption] Error: {e}")),
+    }
+
+    let req = ReplyMessageRequest {
+        reply_token,
+        messages: vec![Message::TextMessage(TextMessage::new(parts.join("\n\n")))],
+        notification_disabled: Some(false),
+    };
+
+    line.messaging_api_client
+        .reply_message(req)
+        .await
+        .map_err(|e| format!("reply_message failed: {e}"))?;
+
+    Ok(())
+}

--- a/examples/axum_example/src/handlers/commands/richmenu.rs
+++ b/examples/axum_example/src/handlers/commands/richmenu.rs
@@ -1,0 +1,42 @@
+//! `/richmenu` command handler.
+//!
+//! Lists all rich menus registered to the bot.
+
+use line_bot_sdk_rust::{
+    client::LINE,
+    line_messaging_api::{
+        apis::MessagingApiApi,
+        models::{Message, ReplyMessageRequest, TextMessage},
+    },
+};
+
+/// Fetches the list of rich menus and replies with a summary.
+pub async fn handle(line: &LINE, reply_token: String) -> Result<(), String> {
+    let text = match line.messaging_api_client.get_rich_menu_list().await {
+        Ok(list) => {
+            if list.richmenus.is_empty() {
+                "No rich menus found.".to_string()
+            } else {
+                let mut lines = vec![format!("Rich Menus ({}):", list.richmenus.len())];
+                for menu in &list.richmenus {
+                    lines.push(format!("- {} ({})", menu.name, menu.rich_menu_id));
+                }
+                lines.join("\n")
+            }
+        }
+        Err(e) => format!("Failed to get rich menus: {e}"),
+    };
+
+    let req = ReplyMessageRequest {
+        reply_token,
+        messages: vec![Message::TextMessage(TextMessage::new(text))],
+        notification_disabled: Some(false),
+    };
+
+    line.messaging_api_client
+        .reply_message(req)
+        .await
+        .map_err(|e| format!("reply_message failed: {e}"))?;
+
+    Ok(())
+}

--- a/examples/axum_example/src/handlers/commands/template.rs
+++ b/examples/axum_example/src/handlers/commands/template.rs
@@ -1,0 +1,56 @@
+//! `/template` command handler.
+//!
+//! Demonstrates sending a ButtonsTemplate with various action types.
+
+use line_bot_sdk_rust::{
+    client::LINE,
+    line_messaging_api::{
+        apis::MessagingApiApi,
+        models::{
+            Action, ButtonsTemplate, Message, MessageAction, PostbackAction, ReplyMessageRequest,
+            Template, TemplateMessage, UriAction,
+        },
+    },
+};
+
+/// Sends a buttons template with postback, message, and URI actions.
+pub async fn handle(line: &LINE, reply_token: String) -> Result<(), String> {
+    let buttons = ButtonsTemplate {
+        title: Some("SDK Actions Demo".to_string()),
+        text: "Choose an action type:".to_string(),
+        actions: vec![
+            Action::PostbackAction(PostbackAction {
+                label: Some("Postback".to_string()),
+                data: Some("action=postback&item=1".to_string()),
+                display_text: Some("Postback tapped!".to_string()),
+                ..Default::default()
+            }),
+            Action::MessageAction(MessageAction {
+                label: Some("Message".to_string()),
+                text: Some("Hello from MessageAction!".to_string()),
+            }),
+            Action::UriAction(UriAction {
+                label: Some("Open GitHub".to_string()),
+                uri: Some("https://github.com/nanato12/line-bot-sdk-rust".to_string()),
+                ..Default::default()
+            }),
+        ],
+        ..ButtonsTemplate::new(String::new(), vec![])
+    };
+
+    let req = ReplyMessageRequest {
+        reply_token,
+        messages: vec![Message::TemplateMessage(TemplateMessage::new(
+            "Actions Demo".to_string(),
+            Template::ButtonsTemplate(buttons),
+        ))],
+        notification_disabled: Some(false),
+    };
+
+    line.messaging_api_client
+        .reply_message(req)
+        .await
+        .map_err(|e| format!("reply_message failed: {e}"))?;
+
+    Ok(())
+}

--- a/examples/axum_example/src/handlers/commands/webhook_info.rs
+++ b/examples/axum_example/src/handlers/commands/webhook_info.rs
@@ -1,0 +1,32 @@
+//! `/webhook` command handler.
+//!
+//! Displays the current webhook endpoint configuration.
+
+use line_bot_sdk_rust::{
+    client::LINE,
+    line_messaging_api::{
+        apis::MessagingApiApi,
+        models::{Message, ReplyMessageRequest, TextMessage},
+    },
+};
+
+/// Fetches and displays the current webhook endpoint URL and active status.
+pub async fn handle(line: &LINE, reply_token: String) -> Result<(), String> {
+    let text = match line.messaging_api_client.get_webhook_endpoint().await {
+        Ok(info) => format!("{info:#?}"),
+        Err(e) => format!("Failed to get webhook endpoint: {e}"),
+    };
+
+    let req = ReplyMessageRequest {
+        reply_token,
+        messages: vec![Message::TextMessage(TextMessage::new(text))],
+        notification_disabled: Some(false),
+    };
+
+    line.messaging_api_client
+        .reply_message(req)
+        .await
+        .map_err(|e| format!("reply_message failed: {e}"))?;
+
+    Ok(())
+}

--- a/examples/axum_example/src/handlers/message.rs
+++ b/examples/axum_example/src/handlers/message.rs
@@ -149,6 +149,18 @@ async fn handle_text(
             "ginfo" => commands::ginfo::handle(line, reply_token, source).await,
             "botinfo" => commands::botinfo::handle(line, reply_token).await,
             "flex" => commands::flex::handle(line, reply_token).await,
+            "image" => commands::image::handle(line, reply_token).await,
+            "location" => commands::location::handle(line, reply_token).await,
+            "template" => commands::template::handle(line, reply_token).await,
+            "confirm" => commands::confirm::handle(line, reply_token).await,
+            "carousel" => commands::carousel::handle(line, reply_token).await,
+            "quick" => commands::quick::handle(line, reply_token).await,
+            "push" => commands::push::handle(line, reply_token, source).await,
+            "loading" => commands::loading::handle(line, reply_token, source).await,
+            "quota" => commands::quota::handle(line, reply_token).await,
+            "richmenu" => commands::richmenu::handle(line, reply_token).await,
+            "members" => commands::members::handle(line, reply_token, source).await,
+            "webhook" => commands::webhook_info::handle(line, reply_token).await,
             _ => {
                 reply(
                     line,

--- a/examples/axum_example/src/handlers/mod.rs
+++ b/examples/axum_example/src/handlers/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! Each module handles a specific LINE webhook event type.
 
+pub mod account_link;
 pub mod beacon;
 pub mod commands;
 pub mod follow;
@@ -13,3 +14,4 @@ pub mod message;
 pub mod postback;
 pub mod unfollow;
 pub mod unsend;
+pub mod video_play_complete;

--- a/examples/axum_example/src/handlers/video_play_complete.rs
+++ b/examples/axum_example/src/handlers/video_play_complete.rs
@@ -1,0 +1,38 @@
+//! Video play complete event handler.
+//!
+//! Triggered when a user finishes watching a video message that has a tracking ID.
+
+use line_bot_sdk_rust::{
+    client::LINE,
+    line_messaging_api::{
+        apis::MessagingApiApi,
+        models::{Message, ReplyMessageRequest, TextMessage},
+    },
+    line_webhook::models::VideoPlayCompleteEvent,
+};
+
+/// Replies with the tracking ID of the completed video.
+pub async fn handle(line: &LINE, event: VideoPlayCompleteEvent) -> Result<(), String> {
+    println!(
+        "[video_play_complete] tracking_id={}",
+        event.video_play_complete.tracking_id
+    );
+
+    let reply_token = event.reply_token;
+
+    let req = ReplyMessageRequest {
+        reply_token,
+        messages: vec![Message::TextMessage(TextMessage::new(format!(
+            "You finished watching the video! (tracking_id: {})",
+            event.video_play_complete.tracking_id
+        )))],
+        notification_disabled: Some(false),
+    };
+
+    line.messaging_api_client
+        .reply_message(req)
+        .await
+        .map_err(|e| format!("reply_message failed: {e}"))?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Add 12 new slash commands demonstrating various Messaging API features: `/image`, `/location`, `/template`, `/confirm`, `/carousel`, `/quick`, `/push`, `/loading`, `/quota`, `/richmenu`, `/members`, `/webhook`
- Add 2 new webhook event handlers: `VideoPlayCompleteEvent`, `AccountLinkEvent`
- Update `/help` command with categorized command list (Message Types, API Features, Actions)

## New Commands
| Command | Description |
|---------|-------------|
| `/image` | Send an ImageMessage |
| `/location` | Send a LocationMessage |
| `/template` | ButtonsTemplate with various actions |
| `/confirm` | ConfirmTemplate with yes/no buttons |
| `/carousel` | CarouselTemplate with multiple columns |
| `/quick` | QuickReply with camera, location, etc. |
| `/push` | PushMessage API demo |
| `/loading` | ShowLoadingAnimation API |
| `/quota` | Message quota and consumption info |
| `/richmenu` | List registered rich menus |
| `/members` | List group/room member IDs |
| `/webhook` | Show webhook endpoint info |

## Test plan
- [ ] `cargo build --manifest-path examples/axum_example/Cargo.toml`
- [ ] `cargo clippy --manifest-path examples/axum_example/Cargo.toml -- -D warnings`
- [ ] Verify each new command responds correctly via LINE

🤖 Generated with [Claude Code](https://claude.com/claude-code)